### PR TITLE
fix: only count open channels in total channels and capacity

### DIFF
--- a/components/ChainSummaryCard.tsx
+++ b/components/ChainSummaryCard.tsx
@@ -24,7 +24,7 @@ const ChainSummaryCard: React.FC<ChainSummaryCardProps> = ({
     <Card className="mb-4">
       <Card.Body>
         <Card.Title>Chain Summary</Card.Title>
-        <div><strong>Total Channels:</strong> {totalChannels.toLocaleString()}</div>
+        <div><strong>Total Open Channels:</strong> {totalChannels.toLocaleString()}</div>
         <div><strong>Total Capacity:</strong> {totalCapacity.toLocaleString()}</div>
         <div><strong>Total Inbound Messages Processed:</strong> {totalInbound.toLocaleString()}</div>
         <div><strong>Total Outbound Messages Processed:</strong> {totalOutbound.toLocaleString()}</div>

--- a/pages/channels.tsx
+++ b/pages/channels.tsx
@@ -66,14 +66,16 @@ export default function ChannelsPage() {
       const outbox = parseNumber(channel.nextOutboxNonce);
       const response = parseNumber(channel.latestResponseReceivedMessageNonce);
 
-      totalCapacity += capacity;
+      if (channel.state === 'Open') {
+        totalCapacity += capacity;
+      }
       totalInbound += Math.max(0, inbox - 1);
       totalOutbound += Math.max(0, response);
       totalPending += Math.max(0, outbox - 1 - response);
     });
 
     return {
-      totalChannels: channels.length,
+      totalChannels: channels.filter(channel => channel.state === 'Open').length,
       totalCapacity,
       totalInbound,
       totalOutbound,


### PR DESCRIPTION
## Changes
- Modified channel stats to only count channels with state 'Open' in total channels count
- Only include capacity from open channels in total capacity calculation
- Updated UI label to clarify we're showing 'Total Open Channels'
- Kept message totals (inbound/outbound/pending) from all channels for historical tracking

## Why
This change ensures that the channel statistics more accurately reflect the current state of the network by:
1. Only counting active channels in the total channels count
2. Only including capacity from active channels in the total capacity
3. Maintaining historical message data from all channels (including closed ones)

## Testing
- Verified that only open channels are counted in the total channels number
- Confirmed that capacity is only included from open channels
- Checked that message totals still include data from all channels
- Verified UI label update to match the new behavior