### PR TITLE
chore: update GitHub Actions to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: 🛎 Checkout


### PR DESCRIPTION
## Changes
- Updated GitHub Actions workflow to use Ubuntu 22.04 instead of 20.04

## Why
Ubuntu 20.04 is approaching end-of-life, and it's good practice to keep our CI/CD environment up to date with the latest LTS version.

## Testing
- Verified that the workflow file syntax is correct
- The change is minimal and only affects the runner version