### PR TITLE
feature: XDM transfer UX improvements

### DIFF
--- a/components/TransferCard.tsx
+++ b/components/TransferCard.tsx
@@ -197,8 +197,8 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
         </div>
 
         {/* From → To */}
-        <div className="row g-2 mb-2 align-items-start">
-          <div className="col-md">
+        <div className="row g-0 mb-2 align-items-center">
+          <div className="col-12 col-md-5">
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               From
             </div>
@@ -233,19 +233,19 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
               )}
             </div>
           </div>
-          <div className="col-12 col-md-auto d-flex align-items-center justify-content-center py-1 py-md-0" style={{ marginTop: '0.75rem' }}>
+          <div className="col-12 col-md-2 d-flex align-items-center justify-content-center py-1 py-md-0">
             {/* Right arrow on md+ screens */}
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-none d-md-block">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-none d-md-block">
               <line x1="5" y1="12" x2="19" y2="12" />
               <polyline points="12 5 19 12 12 19" />
             </svg>
             {/* Down arrow on small screens */}
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-md-none">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-md-none">
               <line x1="12" y1="5" x2="12" y2="19" />
               <polyline points="19 12 12 19 5 12" />
             </svg>
           </div>
-          <div className="col-md">
+          <div className="col-12 col-md-5">
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               To
             </div>

--- a/components/TransferCard.tsx
+++ b/components/TransferCard.tsx
@@ -5,12 +5,11 @@ import {
   getTransferStatus,
   formatChainName,
   formatAmount,
-  truncateHash,
   truncateAddress,
 } from '../utils/fetchTransfers';
 import { TransferProgress, ProgressEntry } from '../utils/fetchTransferProgress';
 import { formatTimeAgo } from '../utils/fetchTimestamps';
-import { getAddressExplorerUrl, NetworkType } from '../config/networks';
+import { getAddressExplorerUrl, getBlockExplorerUrl, NetworkType } from '../config/networks';
 import CopyableText from './CopyableText';
 
 interface TransferCardProps {
@@ -312,36 +311,54 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
 
         <details className="mt-2">
           <summary className="small text-muted" style={{ cursor: 'pointer' }}>
-            <span className="ms-1">Details &middot; Nonce {transfer.nonce} &middot; Channel {transfer.channel_id}</span>
+            <span className="ms-1">Details</span>
           </summary>
           <div className="mt-2 ms-3 small">
-            {transfer.initiated_src_block && (
-              <div className="mb-1">
-                <strong>Initiated:</strong> Block #{transfer.initiated_src_block.block_number.toLocaleString()}
-                <br />
-                <span className="text-muted" title={transfer.initiated_src_block.block_hash}>
-                  {truncateHash(transfer.initiated_src_block.block_hash)}
-                </span>
-              </div>
-            )}
-            {transfer.executed_dst_block && (
-              <div className="mb-1">
-                <strong>Executed:</strong> Block #{transfer.executed_dst_block.block_number.toLocaleString()}
-                <br />
-                <span className="text-muted" title={transfer.executed_dst_block.block_hash}>
-                  {truncateHash(transfer.executed_dst_block.block_hash)}
-                </span>
-              </div>
-            )}
-            {transfer.acknowledged_src_block && (
-              <div className="mb-1">
-                <strong>Acknowledged:</strong> Block #{transfer.acknowledged_src_block.block_number.toLocaleString()}
-                <br />
-                <span className="text-muted" title={transfer.acknowledged_src_block.block_hash}>
-                  {truncateHash(transfer.acknowledged_src_block.block_hash)}
-                </span>
-              </div>
-            )}
+            <div className="border rounded p-2 mb-2" style={{ backgroundColor: '#f8f9fa' }}>
+              <div className="mb-1"><strong>Nonce:</strong> {transfer.nonce}</div>
+              <div><strong>Channel:</strong> {transfer.channel_id}</div>
+            </div>
+            <div className="border rounded p-2" style={{ backgroundColor: '#f0f6ff' }}>
+              {transfer.initiated_src_block && (
+                <div className="mb-1">
+                  <strong>Initiated:</strong>{' '}
+                  <a
+                    href={getBlockExplorerUrl(network as NetworkType, transfer.initiated_src_block.block_number, transfer.src_chain)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-decoration-none"
+                  >
+                    Block #{transfer.initiated_src_block.block_number.toLocaleString()}
+                  </a>
+                </div>
+              )}
+              {transfer.executed_dst_block && (
+                <div className="mb-1">
+                  <strong>Executed:</strong>{' '}
+                  <a
+                    href={getBlockExplorerUrl(network as NetworkType, transfer.executed_dst_block.block_number, transfer.dst_chain)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-decoration-none"
+                  >
+                    Block #{transfer.executed_dst_block.block_number.toLocaleString()}
+                  </a>
+                </div>
+              )}
+              {transfer.acknowledged_src_block && (
+                <div>
+                  <strong>Acknowledged:</strong>{' '}
+                  <a
+                    href={getBlockExplorerUrl(network as NetworkType, transfer.acknowledged_src_block.block_number, transfer.src_chain)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-decoration-none"
+                  >
+                    Block #{transfer.acknowledged_src_block.block_number.toLocaleString()}
+                  </a>
+                </div>
+              )}
+            </div>
           </div>
         </details>
       </Card.Body>

--- a/components/TransferCard.tsx
+++ b/components/TransferCard.tsx
@@ -197,7 +197,7 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
 
         {/* From → To */}
         <div className="row g-0 mb-2 align-items-center">
-          <div className="col-12 col-md-5">
+          <div className="col-12 col-md-5 border rounded p-2" style={{ backgroundColor: '#f8f9fa' }}>
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               From
             </div>
@@ -244,7 +244,7 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
               <polyline points="19 12 12 19 5 12" />
             </svg>
           </div>
-          <div className="col-12 col-md-5">
+          <div className="col-12 col-md-5 border rounded p-2" style={{ backgroundColor: '#f8f9fa' }}>
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               To
             </div>

--- a/components/TransferCard.tsx
+++ b/components/TransferCard.tsx
@@ -202,7 +202,7 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               From
             </div>
-            <div className="fw-semibold small">{formatChainName(transfer.src_chain)}</div>
+            <div className="fw-semibold" style={{ fontSize: '1.2rem' }}>{formatChainName(transfer.src_chain)}</div>
             <div className="d-flex align-items-center gap-1">
               <a
                 href={getAddressExplorerUrl(network as NetworkType, transfer.sender, transfer.src_chain)}
@@ -249,7 +249,7 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
             <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
               To
             </div>
-            <div className="fw-semibold small">{formatChainName(transfer.dst_chain)}</div>
+            <div className="fw-semibold" style={{ fontSize: '1.2rem' }}>{formatChainName(transfer.dst_chain)}</div>
             <div className="d-flex align-items-center gap-1">
               <a
                 href={getAddressExplorerUrl(network as NetworkType, transfer.receiver, transfer.dst_chain)}

--- a/components/TransferCard.tsx
+++ b/components/TransferCard.tsx
@@ -138,11 +138,18 @@ function ProgressSection({
         now={percent}
         label={`${percent.toFixed(0)}%`}
         variant={percent >= 100 ? 'success' : 'secondary'}
-        style={{ height: '0.5rem' }}
       />
     </div>
   );
 }
+
+const STATUS_COLORS: Record<string, string> = {
+  warning: '#f0ad4e',
+  info: '#0dcaf0',
+  success: '#198754',
+  danger: '#dc3545',
+  secondary: '#6c757d',
+};
 
 const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, progress, initiatedAt, network, onSearchAddress }) => {
   const status = getTransferStatus(transfer);
@@ -152,41 +159,50 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
 
   // Tokens are available once the transfer has been executed on the destination
   const tokensAvailable = !!transfer.executed_dst_block;
+  const statusColor = STATUS_COLORS[status.variant] || STATUS_COLORS.secondary;
 
   return (
-    <Card className="mb-4 shadow-sm">
-      <Card.Body className="p-3 p-md-4">
-        {/* Header: status + metadata */}
-        <div className="d-flex flex-wrap justify-content-between align-items-center gap-1 mb-3">
-          <div className="d-flex align-items-center">
-            <span className="me-2" title={status.label}>
-              <StatusIcon statusLabel={status.label} />
+    <Card
+      className="mb-3 shadow-sm"
+      style={{ borderLeft: `4px solid ${statusColor}`, borderTop: 0, borderRight: 0, borderBottom: 0 }}
+    >
+      <Card.Body className="p-3">
+        {/* Header: status icon + text, direction badge, timestamp */}
+        <div className="d-flex flex-wrap justify-content-between align-items-center gap-1 mb-2">
+          <div className="d-flex align-items-center gap-2">
+            <StatusIcon statusLabel={status.label} />
+            <span className="fw-semibold small" style={{ color: statusColor }}>
+              {status.label}
             </span>
-            <Badge bg={isSender ? 'primary' : 'secondary'} className="me-2">
+            <Badge
+              pill
+              bg={isSender ? 'primary' : 'secondary'}
+              className="opacity-75"
+              style={{ fontSize: '0.7rem' }}
+            >
               {isSender ? 'Sent' : 'Received'}
             </Badge>
-            <Badge bg={status.variant}>{status.label}</Badge>
           </div>
-          <span className="text-muted small text-end">
-            {initiatedAt && (
-              <span title={initiatedAt.toLocaleString()}>
-                {formatTimeAgo(initiatedAt)} &middot;{' '}
-              </span>
-            )}
-            Nonce: {transfer.nonce} &middot; Channel: {transfer.channel_id}
-          </span>
+          {initiatedAt && (
+            <span className="text-muted small" title={initiatedAt.toLocaleString()}>
+              {formatTimeAgo(initiatedAt)}
+            </span>
+          )}
         </div>
 
         {/* Amount */}
-        <div className="mb-3">
-          <span className="fs-5 fw-bold">{formatAmount(transfer.amount)} AI3</span>
+        <div className="mb-2">
+          <span className="fs-4 fw-bold">{formatAmount(transfer.amount)}</span>
+          <span className="text-muted ms-1 small">AI3</span>
         </div>
 
         {/* From → To */}
-        <div className="row g-3 mb-3">
-          <div className="col-md-6">
-            <div className="small text-muted mb-1">From</div>
-            <div className="fw-bold">{formatChainName(transfer.src_chain)}</div>
+        <div className="row g-2 mb-2 align-items-start">
+          <div className="col-md">
+            <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              From
+            </div>
+            <div className="fw-semibold small">{formatChainName(transfer.src_chain)}</div>
             <div className="d-flex align-items-center gap-1">
               <a
                 href={getAddressExplorerUrl(network as NetworkType, transfer.sender, transfer.src_chain)}
@@ -217,9 +233,23 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
               )}
             </div>
           </div>
-          <div className="col-md-6">
-            <div className="small text-muted mb-1">To</div>
-            <div className="fw-bold">{formatChainName(transfer.dst_chain)}</div>
+          <div className="col-12 col-md-auto d-flex align-items-center justify-content-center py-1 py-md-0" style={{ marginTop: '0.75rem' }}>
+            {/* Right arrow on md+ screens */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-none d-md-block">
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+            {/* Down arrow on small screens */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-muted d-md-none">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <polyline points="19 12 12 19 5 12" />
+            </svg>
+          </div>
+          <div className="col-md">
+            <div className="text-muted mb-1" style={{ fontSize: '0.65rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              To
+            </div>
+            <div className="fw-semibold small">{formatChainName(transfer.dst_chain)}</div>
             <div className="d-flex align-items-center gap-1">
               <a
                 href={getAddressExplorerUrl(network as NetworkType, transfer.receiver, transfer.dst_chain)}
@@ -253,7 +283,7 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
         </div>
 
         {/* Status description */}
-        <div className="small text-muted mb-2">{status.description}</div>
+        <div className="small text-muted" title={status.description}>{status.description}</div>
 
         {/* Token availability progress — shown prominently for pending transfers */}
         {progress?.availability && (
@@ -280,11 +310,11 @@ const TransferCard: React.FC<TransferCardProps> = ({ transfer, searchAddress, pr
           />
         )}
 
-        <details className="mt-3">
+        <details className="mt-2">
           <summary className="small text-muted" style={{ cursor: 'pointer' }}>
-            Block Details
+            <span className="ms-1">Details &middot; Nonce {transfer.nonce} &middot; Channel {transfer.channel_id}</span>
           </summary>
-          <div className="mt-2 small">
+          <div className="mt-2 ms-3 small">
             {transfer.initiated_src_block && (
               <div className="mb-1">
                 <strong>Initiated:</strong> Block #{transfer.initiated_src_block.block_number.toLocaleString()}

--- a/components/TransferList.tsx
+++ b/components/TransferList.tsx
@@ -102,12 +102,12 @@ const TransferList: React.FC<TransferListProps> = ({ transfers, searchAddress, p
           )}
         </button>
       </div>
-      {transfers.map((transfer, index) => (
+      {transfers.map((transfer) => (
         <TransferCard
-          key={transferKey(transfer, index)}
+          key={transferKey(transfer)}
           transfer={transfer}
           searchAddress={searchAddress}
-          progress={progress?.get(transferKey(transfer, index))}
+          progress={progress?.get(transferKey(transfer))}
           initiatedAt={timestamps?.get(transferTimestampKey(transfer))}
           network={network}
           onSearchAddress={onSearchAddress}

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -46,6 +46,22 @@ export function getAddressExplorerUrl(
   return `${config.explorers.consensus}/account/${address}`;
 }
 
+/**
+ * Build an explorer URL for a block number.
+ * Consensus blocks go to Subscan, domain blocks go to Blockscout.
+ */
+export function getBlockExplorerUrl(
+  network: NetworkType,
+  blockNumber: number,
+  chain: string
+): string {
+  const config = NETWORKS[network];
+  if (chain === 'Consensus') {
+    return `${config.explorers.consensus}/block/${blockNumber}`;
+  }
+  return `${config.explorers.autoEvm}/block/${blockNumber}`;
+}
+
 // XDM confirmation depths in domain blocks
 export const CONSENSUS_TO_DOMAIN_DEPTH = 100;
 export const DOMAIN_TO_CONSENSUS_DEPTH = 14_400;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,6 +1027,17 @@
         "scale-ts": "^1.6.0"
       }
     },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
+      "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/utils": "0.1.0"
+      }
+    },
     "node_modules/@polkadot-api/utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
@@ -1305,7 +1316,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.4.3.tgz",
       "integrity": "sha512-6v2zvg8l7W22XvjYf7qv9tPQdYl2E6aXY94M4TZKsXZxmlS5BoG+A9Aq0+Gw8zBUjupjEmUkA6Y//msO8Zisug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-bigint": "13.4.3",
         "@polkadot/x-global": "13.4.3",
@@ -1491,7 +1501,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.4.3.tgz",
       "integrity": "sha512-pskXP/S2jROZ6aASExsUFlNp7GbJvQikKogvyvMMCzNIbUYLxpLuquLRa3MOORx2c0SNsENg90cx/zHT+IjPRQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "13.4.3",
         "tslib": "^2.8.0"
@@ -1549,7 +1558,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1770,7 +1778,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1836,7 +1843,6 @@
       "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.27.0",
         "@typescript-eslint/types": "8.27.0",
@@ -2200,7 +2206,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3133,7 +3138,6 @@
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3308,7 +3312,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5446,7 +5449,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5487,7 +5489,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -5677,7 +5678,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -5966,6 +5966,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/smoldot": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
+      "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6228,7 +6238,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6401,7 +6410,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,10 +6,22 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <nav className="navbar navbar-light bg-white border-bottom">
-        <div className="container">
+        <div className="container d-flex justify-content-between align-items-center">
           <Link href="/" className="navbar-brand fw-bold">
             Autonomys Helpers
           </Link>
+          <a
+            href="https://github.com/autonomys-community/autonomys-helpers"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="d-flex align-items-center gap-1 text-muted text-decoration-none small"
+            title="View source on GitHub"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+            Contribute
+          </a>
         </div>
       </nav>
       <Component {...pageProps} />

--- a/pages/xdm/transfers.tsx
+++ b/pages/xdm/transfers.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { Form, Button, Spinner, Alert } from 'react-bootstrap';
 import TransferList from '../../components/TransferList';
 import NetworkSelector from '../../components/NetworkSelector';
 import { fetchTransfers, XdmTransfer } from '../../utils/fetchTransfers';
 import { fetchTransferProgress, TransferProgress } from '../../utils/fetchTransferProgress';
-import { fetchTransferTimestamps } from '../../utils/fetchTimestamps';
+import { fetchTransferTimestamps, transferTimestampKey } from '../../utils/fetchTimestamps';
 import { NETWORKS, NetworkType } from '../../config/networks';
 
 export default function TransfersPage() {
@@ -24,6 +24,52 @@ export default function TransfersPage() {
   const [progressLoading, setProgressLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Sort transfers by timestamp (newest first) once timestamps are available,
+  // falling back to nonce order until then.
+  // ---------------------------------------------------------------------------
+  const sortedTransfers = useMemo(() => {
+    if (timestamps.size === 0) return transfers;
+    return [...transfers].sort((a, b) => {
+      const tsA = timestamps.get(transferTimestampKey(a));
+      const tsB = timestamps.get(transferTimestampKey(b));
+      if (tsA && tsB) return tsB.getTime() - tsA.getTime();
+      if (tsA && !tsB) return -1; // timestamped items before non-timestamped
+      if (!tsA && tsB) return 1;
+      return parseInt(b.nonce, 10) - parseInt(a.nonce, 10);
+    });
+  }, [transfers, timestamps]);
+
+  // ---------------------------------------------------------------------------
+  // Fade transition: briefly hide the list when the sort order changes so
+  // the re-ordering isn't jarring.
+  // ---------------------------------------------------------------------------
+  const hadTimestamps = useRef(false);
+  const [listOpacity, setListOpacity] = useState(1);
+
+  useLayoutEffect(() => {
+    if (timestamps.size === 0) {
+      hadTimestamps.current = false;
+      return;
+    }
+    if (!hadTimestamps.current && transfers.length > 1) {
+      hadTimestamps.current = true;
+      setListOpacity(0);
+    }
+  }, [timestamps, transfers]);
+
+  useEffect(() => {
+    if (listOpacity === 0) {
+      // Double rAF: the first frame lets the browser paint at opacity 0,
+      // the second frame triggers the CSS transition to opacity 1.
+      let rafId: number;
+      rafId = requestAnimationFrame(() => {
+        rafId = requestAnimationFrame(() => setListOpacity(1));
+      });
+      return () => cancelAnimationFrame(rafId);
+    }
+  }, [listOpacity]);
 
   const loadTimestamps = useCallback(
     async (network: NetworkType, data: XdmTransfer[]) => {
@@ -352,14 +398,16 @@ export default function TransfersPage() {
               )}
             </div>
           )}
-          <TransferList
-            transfers={transfers}
-            searchAddress={submittedAddress}
-            progress={progress}
-            timestamps={timestamps}
-            network={selectedNetwork}
-            onSearchAddress={searchFor}
-          />
+          <div style={{ opacity: listOpacity, transition: 'opacity 0.3s ease' }}>
+            <TransferList
+              transfers={sortedTransfers}
+              searchAddress={submittedAddress}
+              progress={progress}
+              timestamps={timestamps}
+              network={selectedNetwork}
+              onSearchAddress={searchFor}
+            />
+          </div>
         </>
       )}
 

--- a/utils/fetchTransferProgress.ts
+++ b/utils/fetchTransferProgress.ts
@@ -22,8 +22,8 @@ export interface TransferProgress {
 }
 
 /** Build a unique key for a transfer to use in the progress map. */
-export function transferKey(transfer: XdmTransfer, index: number): string {
-  return `${transfer.channel_id}-${transfer.nonce}-${transfer.src_chain}-${index}`;
+export function transferKey(transfer: XdmTransfer): string {
+  return `${transfer.channel_id}-${transfer.nonce}-${transfer.src_chain}`;
 }
 
 /** Extract the domain ID from a chain string like "Domain(0)". Returns null for Consensus. */
@@ -98,7 +98,7 @@ export async function fetchTransferProgress(
 
     // Initialise progress entries for each in-flight transfer
     for (const { transfer, index } of inFlight) {
-      const key = transferKey(transfer, index);
+      const key = transferKey(transfer);
       const isPending = !transfer.executed_dst_block;
       const isFromConsensus = transfer.src_chain === 'Consensus';
 

--- a/utils/fetchTransfers.ts
+++ b/utils/fetchTransfers.ts
@@ -39,7 +39,8 @@ export async function fetchTransfers(
   }
 
   const data: XdmTransfer[] = await response.json();
-  // Sort by nonce descending so the latest transfer is always first
+  // Initial sort by nonce descending. The page re-sorts by on-chain timestamp
+  // once timestamps have loaded (see sortedTransfers in transfers.tsx).
   data.sort((a, b) => parseInt(b.nonce, 10) - parseInt(a.nonce, 10));
   return data;
 }


### PR DESCRIPTION
### Summary

Improves the usability and visual polish of the XDM transfer status page with chronological sorting, a refreshed card design, and quality-of-life additions.

### Changes

- **Sort transfers by timestamp instead of nonce** - Transfers are now ordered chronologically using on-chain block timestamps.
- **Revamp transfer card styling** - Cards now feature a status-coloured left border for at-a-glance scanning, a cleaner header (icon + coloured status text + pill badge), larger amount display with separated unit text, and tighter vertical spacing between cards.
- **Move nonce/channel to collapsible details** - Technical metadata (nonce, channel ID) is moved out of the card header into the expandable details section. Block numbers in the details section now link directly to the relevant block explorer (Subscan for consensus, Blockscout for Auto EVM). Block hashes have been removed as redundant.
- **Make progress bars consistent height** - The secondary (completion) progress bar now renders at the same height as the primary (availability) bar.
- **Add "Contribute" link to site header** - A GitHub logo and "Contribute" link in the navbar points to the repository, visible on every page.