### PR TITLE
feature: Add XDM send transfer page

### DIFF
--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -104,7 +104,7 @@ const SendForm: React.FC<SendFormProps> = ({
     if (!amount.trim()) return 'Amount is required.';
     const numAmount = parseFloat(amount);
     if (isNaN(numAmount) || numAmount <= 0) return 'Amount must be greater than 0.';
-    if (numAmount < 0.0001) return 'Amount is below the minimum transfer amount.';
+    if (numAmount < 1) return 'Minimum XDM transfer amount is 1 AI3.';
 
     if (balance !== null) {
       const balNum = parseFloat(balance);

--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -46,6 +46,14 @@ const SendForm: React.FC<SendFormProps> = ({
     ? `~10 minutes (${CONSENSUS_TO_DOMAIN_DEPTH} domain blocks)`
     : `~1 day (${DOMAIN_TO_CONSENSUS_DEPTH.toLocaleString()} domain blocks)`;
 
+  // Reset form fields when direction or network changes
+  useEffect(() => {
+    setRecipient('');
+    setAmount('');
+    setValidationError(null);
+    setBalance(null);
+  }, [direction, network]);
+
   // Fetch balance when sender address changes
   useEffect(() => {
     if (!senderAddress) {

--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -119,7 +119,12 @@ const SendForm: React.FC<SendFormProps> = ({
 
   const handleConfirm = useCallback(async () => {
     setShowConfirm(false);
-    await onSubmit(recipient.trim(), amount.trim());
+    try {
+      await onSubmit(recipient.trim(), amount.trim());
+    } catch {
+      // Error is handled by the parent via submitError prop;
+      // catch here to prevent unhandled promise rejection.
+    }
   }, [onSubmit, recipient, amount]);
 
   const handleSetMax = useCallback(() => {

--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -93,7 +93,7 @@ const SendForm: React.FC<SendFormProps> = ({
 
     if (isConsensusToEvm) {
       if (!isValidEvmAddress(recipient.trim())) {
-        return 'Invalid EVM address. Must be 0x followed by 40 hex characters.';
+        return 'Invalid EVM address. Please enter a valid checksummed address (0x…).';
       }
     } else {
       if (!isValidSubstrateAddress(recipient.trim())) {

--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -1,0 +1,282 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Form, Button, Spinner, Alert, Card, Modal } from 'react-bootstrap';
+import type { TransferDirection } from '../utils/xdmTransfer';
+import {
+  isValidEvmAddress,
+  isValidSubstrateAddress,
+  getConsensusBalance,
+  getEvmBalance,
+} from '../utils/xdmTransfer';
+import type { NetworkType } from '../config/networks';
+import { CONSENSUS_TO_DOMAIN_DEPTH, DOMAIN_TO_CONSENSUS_DEPTH } from '../config/networks';
+import type { BrowserProvider } from 'ethers';
+
+interface SendFormProps {
+  direction: TransferDirection;
+  network: NetworkType;
+  senderAddress: string | null;
+  evmProvider: BrowserProvider | null;
+  onSubmit: (recipient: string, amount: string) => Promise<void>;
+  isSubmitting: boolean;
+  submitError: string | null;
+}
+
+const SendForm: React.FC<SendFormProps> = ({
+  direction,
+  network,
+  senderAddress,
+  evmProvider,
+  onSubmit,
+  isSubmitting,
+  submitError,
+}) => {
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [balance, setBalance] = useState<string | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const isConsensusToEvm = direction === 'consensus-to-evm';
+  const recipientLabel = isConsensusToEvm ? 'Recipient EVM Address (0x…)' : 'Recipient Substrate Address';
+  const recipientPlaceholder = isConsensusToEvm
+    ? '0x0000000000000000000000000000000000000000'
+    : 'subsp…';
+  const confirmationTime = isConsensusToEvm
+    ? `~10 minutes (${CONSENSUS_TO_DOMAIN_DEPTH} domain blocks)`
+    : `~1 day (${DOMAIN_TO_CONSENSUS_DEPTH.toLocaleString()} domain blocks)`;
+
+  // Fetch balance when sender address changes
+  useEffect(() => {
+    if (!senderAddress) {
+      setBalance(null);
+      return;
+    }
+
+    let cancelled = false;
+    setBalanceLoading(true);
+
+    const fetchBalance = async () => {
+      try {
+        let bal: string;
+        if (isConsensusToEvm) {
+          bal = await getConsensusBalance(network, senderAddress);
+        } else if (evmProvider) {
+          bal = await getEvmBalance(evmProvider, senderAddress);
+        } else {
+          setBalance(null);
+          return;
+        }
+        if (!cancelled) setBalance(bal);
+      } catch (err) {
+        console.error('Failed to fetch balance:', err);
+        if (!cancelled) setBalance(null);
+      } finally {
+        if (!cancelled) setBalanceLoading(false);
+      }
+    };
+
+    fetchBalance();
+    return () => { cancelled = true; };
+  }, [senderAddress, network, isConsensusToEvm, evmProvider]);
+
+  const validateForm = useCallback((): string | null => {
+    if (!recipient.trim()) return 'Recipient address is required.';
+
+    if (isConsensusToEvm) {
+      if (!isValidEvmAddress(recipient.trim())) {
+        return 'Invalid EVM address. Must be 0x followed by 40 hex characters.';
+      }
+    } else {
+      if (!isValidSubstrateAddress(recipient.trim())) {
+        return 'Invalid Substrate address.';
+      }
+    }
+
+    if (!amount.trim()) return 'Amount is required.';
+    const numAmount = parseFloat(amount);
+    if (isNaN(numAmount) || numAmount <= 0) return 'Amount must be greater than 0.';
+    if (numAmount < 0.0001) return 'Amount is below the minimum transfer amount.';
+
+    if (balance !== null) {
+      const balNum = parseFloat(balance);
+      if (numAmount > balNum) return 'Insufficient balance.';
+    }
+
+    return null;
+  }, [recipient, amount, isConsensusToEvm, balance]);
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+    const error = validateForm();
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+    setValidationError(null);
+    setShowConfirm(true);
+  }, [validateForm]);
+
+  const handleConfirm = useCallback(async () => {
+    setShowConfirm(false);
+    await onSubmit(recipient.trim(), amount.trim());
+  }, [onSubmit, recipient, amount]);
+
+  const handleSetMax = useCallback(() => {
+    if (balance !== null) {
+      // Leave a small buffer for tx fees
+      const maxAmount = Math.max(0, parseFloat(balance) - 0.01);
+      setAmount(maxAmount > 0 ? maxAmount.toFixed(4) : '0');
+    }
+  }, [balance]);
+
+  if (!senderAddress) {
+    return (
+      <Card className="bg-light">
+        <Card.Body className="text-center text-muted py-4">
+          Connect your wallet above to send a transfer.
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <Card.Body>
+          <Form onSubmit={handleSubmit}>
+            <Form.Group className="mb-3">
+              <Form.Label className="fw-bold small">From</Form.Label>
+              <div className="d-flex align-items-center gap-2">
+                <Form.Control
+                  type="text"
+                  value={senderAddress}
+                  disabled
+                  className="font-monospace small"
+                />
+                <div className="text-nowrap small">
+                  {balanceLoading ? (
+                    <Spinner animation="border" size="sm" />
+                  ) : balance !== null ? (
+                    <span className="fw-bold">{balance} AI3</span>
+                  ) : null}
+                </div>
+              </div>
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label className="fw-bold small">{recipientLabel}</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder={recipientPlaceholder}
+                value={recipient}
+                onChange={(e) => {
+                  setRecipient(e.target.value);
+                  setValidationError(null);
+                }}
+                disabled={isSubmitting}
+                className="font-monospace"
+              />
+            </Form.Group>
+
+            <Form.Group className="mb-3">
+              <Form.Label className="fw-bold small">Amount (AI3)</Form.Label>
+              <div className="d-flex gap-2">
+                <Form.Control
+                  type="number"
+                  step="any"
+                  min="0"
+                  placeholder="0.0"
+                  value={amount}
+                  onChange={(e) => {
+                    setAmount(e.target.value);
+                    setValidationError(null);
+                  }}
+                  disabled={isSubmitting}
+                />
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={handleSetMax}
+                  disabled={!balance || isSubmitting}
+                  className="flex-shrink-0"
+                >
+                  MAX
+                </Button>
+              </div>
+            </Form.Group>
+
+            <div className="mb-3 p-2 bg-light rounded small">
+              <strong>Estimated confirmation time:</strong> {confirmationTime}
+            </div>
+
+            {validationError && (
+              <Alert variant="warning" className="py-2 small">
+                {validationError}
+              </Alert>
+            )}
+
+            {submitError && (
+              <Alert variant="danger" className="py-2 small">
+                {submitError}
+              </Alert>
+            )}
+
+            <Button
+              type="submit"
+              variant="primary"
+              className="w-100"
+              disabled={isSubmitting || !senderAddress}
+            >
+              {isSubmitting ? (
+                <>
+                  <Spinner as="span" animation="border" size="sm" className="me-2" />
+                  Sending Transfer…
+                </>
+              ) : (
+                'Send Transfer'
+              )}
+            </Button>
+          </Form>
+        </Card.Body>
+      </Card>
+
+      <Modal show={showConfirm} onHide={() => setShowConfirm(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title className="fs-5">Confirm Transfer</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="mb-2">
+            <strong className="small text-muted">Direction</strong>
+            <div>{isConsensusToEvm ? 'Consensus → Auto EVM' : 'Auto EVM → Consensus'}</div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">From</strong>
+            <div className="font-monospace small text-break">{senderAddress}</div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">To</strong>
+            <div className="font-monospace small text-break">{recipient}</div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">Amount</strong>
+            <div className="fs-5 fw-bold">{amount} AI3</div>
+          </div>
+          <div className="p-2 bg-light rounded small">
+            <strong>Estimated confirmation time:</strong> {confirmationTime}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setShowConfirm(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleConfirm}>
+            Confirm &amp; Send
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default SendForm;

--- a/components/wallet/EvmWalletConnect.tsx
+++ b/components/wallet/EvmWalletConnect.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Button, Spinner, Alert } from 'react-bootstrap';
+
+interface EvmWalletConnectProps {
+  isConnected: boolean;
+  isLoading: boolean;
+  address: string | null;
+  chainId: number | null;
+  expectedChainId: number;
+  expectedChainName: string;
+  error: string | null;
+  isMetaMaskInstalled: boolean;
+  onConnect: () => Promise<void>;
+  onDisconnect: () => void;
+  onSwitchChain: () => Promise<void>;
+  onClearError: () => void;
+}
+
+function shortenEvmAddress(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+const EvmWalletConnect: React.FC<EvmWalletConnectProps> = ({
+  isConnected,
+  isLoading,
+  address,
+  chainId,
+  expectedChainId,
+  expectedChainName,
+  error,
+  isMetaMaskInstalled,
+  onConnect,
+  onDisconnect,
+  onSwitchChain,
+  onClearError,
+}) => {
+  const isWrongChain = isConnected && chainId !== null && chainId !== expectedChainId;
+
+  if (isConnected && address) {
+    return (
+      <div>
+        <div className="d-flex align-items-center gap-2">
+          <span className={`badge ${isWrongChain ? 'bg-warning text-dark' : 'bg-success'}`}>
+            {isWrongChain ? 'Wrong Network' : 'Connected'}
+          </span>
+          <span className="small" style={{ fontFamily: 'monospace' }}>
+            {shortenEvmAddress(address)}
+          </span>
+          <Button variant="outline-secondary" size="sm" onClick={onDisconnect}>
+            Disconnect
+          </Button>
+        </div>
+        <div className="text-muted small mt-1" style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+          {address}
+        </div>
+
+        {isWrongChain && (
+          <Alert variant="warning" className="mt-2 py-2 small">
+            Please switch to <strong>{expectedChainName}</strong> (Chain ID: {expectedChainId}).
+            <Button
+              variant="warning"
+              size="sm"
+              className="ms-2"
+              onClick={onSwitchChain}
+            >
+              Switch Network
+            </Button>
+          </Alert>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {error && (
+        <Alert variant="danger" dismissible onClose={onClearError} className="mb-2 py-2 small">
+          {error}
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <div className="d-flex align-items-center gap-2 text-muted">
+          <Spinner animation="border" size="sm" />
+          <span className="small">Connecting wallet…</span>
+        </div>
+      ) : isMetaMaskInstalled ? (
+        <Button
+          variant="outline-primary"
+          size="sm"
+          onClick={onConnect}
+          className="d-flex align-items-center gap-1"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <path d="M22.5 4.5L13.5 1.5L4.5 4.5L1.5 12L4.5 19.5L13.5 22.5L22.5 19.5L25.5 12L22.5 4.5Z" fill="#E2761B" stroke="#E2761B" strokeWidth="0.5"/>
+          </svg>
+          Connect MetaMask
+        </Button>
+      ) : (
+        <div className="small text-muted">
+          MetaMask is not installed.{' '}
+          <a
+            href="https://metamask.io/download/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Install MetaMask
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EvmWalletConnect;

--- a/components/wallet/SubstrateWalletConnect.tsx
+++ b/components/wallet/SubstrateWalletConnect.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { Button, Dropdown, Spinner, Alert } from 'react-bootstrap';
+import type { Wallet, WalletAccount } from '@autonomys/auto-wallet';
+
+interface SubstrateWalletConnectProps {
+  isConnected: boolean;
+  isLoading: boolean;
+  connectionError: string | null;
+  selectedAccount: WalletAccount | null;
+  accounts: WalletAccount[];
+  availableWallets: Wallet[];
+  onConnect: (extensionName: string) => Promise<void>;
+  onDisconnect: () => void;
+  onSelectAccount: (address: string) => void;
+  onClearError: () => void;
+}
+
+function shortenAddress(addr: string, chars = 6): string {
+  if (addr.length <= chars * 2 + 3) return addr;
+  return `${addr.slice(0, chars)}…${addr.slice(-chars)}`;
+}
+
+const SubstrateWalletConnect: React.FC<SubstrateWalletConnectProps> = ({
+  isConnected,
+  isLoading,
+  connectionError,
+  selectedAccount,
+  accounts,
+  availableWallets,
+  onConnect,
+  onDisconnect,
+  onSelectAccount,
+  onClearError,
+}) => {
+  if (isConnected && selectedAccount) {
+    return (
+      <div>
+        <div className="d-flex align-items-center gap-2">
+          <span className="badge bg-success">Connected</span>
+          <Dropdown>
+            <Dropdown.Toggle variant="outline-secondary" size="sm">
+              {selectedAccount.name || shortenAddress(selectedAccount.address)}
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+              {accounts.map((acc) => (
+                <Dropdown.Item
+                  key={acc.address}
+                  active={acc.address === selectedAccount.address}
+                  onClick={() => onSelectAccount(acc.address)}
+                >
+                  <div className="fw-bold small">{acc.name || 'Account'}</div>
+                  <div className="text-muted" style={{ fontSize: '0.75rem' }}>
+                    {shortenAddress(acc.address)}
+                  </div>
+                </Dropdown.Item>
+              ))}
+              <Dropdown.Divider />
+              <Dropdown.Item onClick={onDisconnect} className="text-danger">
+                Disconnect
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        </div>
+        <div className="text-muted small mt-1" style={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+          {selectedAccount.address}
+        </div>
+      </div>
+    );
+  }
+
+  const installedWallets = availableWallets.filter((w) => w.installed);
+  const notInstalledWallets = availableWallets.filter((w) => !w.installed);
+
+  return (
+    <div>
+      {connectionError && (
+        <Alert variant="danger" dismissible onClose={onClearError} className="mb-2 py-2 small">
+          {connectionError}
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <div className="d-flex align-items-center gap-2 text-muted">
+          <Spinner animation="border" size="sm" />
+          <span className="small">Connecting wallet…</span>
+        </div>
+      ) : (
+        <>
+          {installedWallets.length > 0 ? (
+            <div className="d-flex flex-wrap gap-2">
+              {installedWallets.map((wallet) => (
+                <Button
+                  key={wallet.extensionName}
+                  variant="outline-primary"
+                  size="sm"
+                  onClick={() => onConnect(wallet.extensionName)}
+                  className="d-flex align-items-center gap-1"
+                >
+                  {wallet.logo && (
+                    <img
+                      src={wallet.logo.src}
+                      alt={wallet.logo.alt}
+                      width={18}
+                      height={18}
+                    />
+                  )}
+                  {wallet.title}
+                </Button>
+              ))}
+            </div>
+          ) : (
+            <div className="text-muted small">
+              No Substrate wallets detected.
+            </div>
+          )}
+
+          {notInstalledWallets.length > 0 && (
+            <div className="mt-2 small text-muted">
+              Not installed:{' '}
+              {notInstalledWallets.map((wallet, i) => (
+                <span key={wallet.extensionName}>
+                  {i > 0 && ', '}
+                  <a
+                    href={wallet.installUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {wallet.title}
+                  </a>
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SubstrateWalletConnect;

--- a/components/wallet/useEvmWallet.ts
+++ b/components/wallet/useEvmWallet.ts
@@ -1,0 +1,194 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { BrowserProvider, JsonRpcSigner } from 'ethers';
+
+interface EvmWalletState {
+  isConnected: boolean;
+  isLoading: boolean;
+  address: string | null;
+  chainId: number | null;
+  signer: JsonRpcSigner | null;
+  provider: BrowserProvider | null;
+  error: string | null;
+  isMetaMaskInstalled: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  switchChain: (chainId: number, chainName: string, rpcUrl: string) => Promise<void>;
+  clearError: () => void;
+}
+
+declare global {
+  interface Window {
+    ethereum?: {
+      isMetaMask?: boolean;
+      request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+      on: (event: string, handler: (...args: unknown[]) => void) => void;
+      removeListener: (event: string, handler: (...args: unknown[]) => void) => void;
+    };
+  }
+}
+
+/**
+ * React hook for EVM wallet connection via window.ethereum (MetaMask).
+ * Uses ethers.js BrowserProvider for a lightweight, standards-based approach.
+ */
+export function useEvmWallet(): EvmWalletState {
+  const [isConnected, setIsConnected] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [address, setAddress] = useState<string | null>(null);
+  const [chainId, setChainId] = useState<number | null>(null);
+  const [signer, setSigner] = useState<JsonRpcSigner | null>(null);
+  const [provider, setProvider] = useState<BrowserProvider | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  const isMetaMaskInstalled = typeof window !== 'undefined' && !!window.ethereum;
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const disconnect = useCallback(() => {
+    setIsConnected(false);
+    setAddress(null);
+    setChainId(null);
+    setSigner(null);
+    setProvider(null);
+    setError(null);
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!window.ethereum) {
+      setError('MetaMask is not installed. Please install MetaMask to continue.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const browserProvider = new BrowserProvider(window.ethereum);
+      await browserProvider.send('eth_requestAccounts', []);
+      const jsonRpcSigner = await browserProvider.getSigner();
+      const addr = await jsonRpcSigner.getAddress();
+      const network = await browserProvider.getNetwork();
+
+      if (mountedRef.current) {
+        setProvider(browserProvider);
+        setSigner(jsonRpcSigner);
+        setAddress(addr);
+        setChainId(Number(network.chainId));
+        setIsConnected(true);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        const msg = err instanceof Error ? err.message : 'Failed to connect wallet';
+        if (msg.includes('user rejected')) {
+          setError('Connection rejected. Please try again.');
+        } else {
+          setError(msg);
+        }
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  const switchChain = useCallback(async (targetChainId: number, chainName: string, rpcUrl: string) => {
+    if (!window.ethereum) return;
+
+    const hexChainId = '0x' + targetChainId.toString(16);
+    try {
+      await window.ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: hexChainId }],
+      });
+    } catch (switchError: unknown) {
+      // Chain not added yet — add it
+      if (switchError && typeof switchError === 'object' && 'code' in switchError && (switchError as { code: number }).code === 4902) {
+        try {
+          await window.ethereum.request({
+            method: 'wallet_addEthereumChain',
+            params: [{
+              chainId: hexChainId,
+              chainName,
+              nativeCurrency: { name: 'AI3', symbol: 'AI3', decimals: 18 },
+              rpcUrls: [rpcUrl],
+            }],
+          });
+        } catch (addError) {
+          setError(addError instanceof Error ? addError.message : 'Failed to add network');
+        }
+      } else {
+        setError(switchError instanceof Error ? switchError.message : 'Failed to switch network');
+      }
+    }
+  }, []);
+
+  // Listen for account and chain changes
+  useEffect(() => {
+    if (!window.ethereum || !isConnected) return;
+
+    const handleAccountsChanged = async (...args: unknown[]) => {
+      const accounts = args[0] as string[];
+      if (accounts.length === 0) {
+        disconnect();
+      } else if (mountedRef.current) {
+        setAddress(accounts[0]);
+        // Refresh signer with new account
+        if (provider) {
+          try {
+            const newSigner = await provider.getSigner();
+            setSigner(newSigner);
+          } catch {
+            // Signer refresh failed, reconnect
+            disconnect();
+          }
+        }
+      }
+    };
+
+    const handleChainChanged = (...args: unknown[]) => {
+      const newChainId = args[0] as string;
+      if (mountedRef.current) {
+        setChainId(parseInt(newChainId, 16));
+        // Refresh provider and signer on chain change
+        const newProvider = new BrowserProvider(window.ethereum!);
+        setProvider(newProvider);
+        newProvider.getSigner().then(s => {
+          if (mountedRef.current) setSigner(s);
+        }).catch(() => {
+          if (mountedRef.current) disconnect();
+        });
+      }
+    };
+
+    window.ethereum.on('accountsChanged', handleAccountsChanged);
+    window.ethereum.on('chainChanged', handleChainChanged);
+
+    return () => {
+      window.ethereum?.removeListener('accountsChanged', handleAccountsChanged);
+      window.ethereum?.removeListener('chainChanged', handleChainChanged);
+    };
+  }, [isConnected, provider, disconnect]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  return {
+    isConnected,
+    isLoading,
+    address,
+    chainId,
+    signer,
+    provider,
+    error,
+    isMetaMaskInstalled,
+    connect,
+    disconnect,
+    switchChain,
+    clearError,
+  };
+}

--- a/components/wallet/useSubstrateWallet.ts
+++ b/components/wallet/useSubstrateWallet.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { createWalletStore } from '@autonomys/auto-wallet';
+import type { WalletState } from '@autonomys/auto-wallet';
+
+// Singleton store instance — shared across all components
+let storeInstance: ReturnType<typeof createWalletStore> | null = null;
+
+function getStore() {
+  if (!storeInstance) {
+    storeInstance = createWalletStore({
+      dappName: 'Autonomys Helpers',
+      ss58Prefix: 6094,
+      storageKey: 'autonomys-helpers-substrate-wallet',
+    });
+  }
+  return storeInstance;
+}
+
+type WalletSelectors = Pick<
+  WalletState,
+  | 'isConnected'
+  | 'isLoading'
+  | 'loadingType'
+  | 'connectionError'
+  | 'selectedWallet'
+  | 'selectedAccount'
+  | 'accounts'
+  | 'injector'
+  | 'availableWallets'
+  | 'connectWallet'
+  | 'disconnectWallet'
+  | 'selectAccount'
+  | 'clearError'
+>;
+
+/**
+ * React hook wrapping @autonomys/auto-wallet Zustand store.
+ * Uses a singleton store so wallet state is shared across the app.
+ */
+export function useSubstrateWallet(): WalletSelectors {
+  const store = getStore();
+  const detected = useRef(false);
+
+  // Detect wallets once on mount
+  useEffect(() => {
+    if (!detected.current) {
+      detected.current = true;
+      store.getState().detectWallets();
+    }
+  }, [store]);
+
+  const state = store(useShallow((s) => ({
+    isConnected: s.isConnected,
+    isLoading: s.isLoading,
+    loadingType: s.loadingType,
+    connectionError: s.connectionError,
+    selectedWallet: s.selectedWallet,
+    selectedAccount: s.selectedAccount,
+    accounts: s.accounts,
+    injector: s.injector,
+    availableWallets: s.availableWallets,
+    connectWallet: s.connectWallet,
+    disconnectWallet: s.disconnectWallet,
+    selectAccount: s.selectAccount,
+    clearError: s.clearError,
+  })));
+
+  return state;
+}

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -1,10 +1,14 @@
 export const NETWORKS = {
   mainnet: {
     name: 'Mainnet',
+    networkId: 'mainnet' as const,
     rpc: {
       consensus: 'wss://rpc.mainnet.subspace.foundation/ws',
       autoEvm: 'wss://auto-evm.mainnet.autonomys.xyz/ws',
     },
+    evmRpcHttp: 'https://auto-evm.mainnet.autonomys.xyz/ws',
+    evmChainId: 870,
+    domainId: 0,
     indexer: 'https://indexer-api.mainnet.autonomys.xyz/v1/xdm',
     explorers: {
       consensus: 'https://autonomys.subscan.io',
@@ -13,10 +17,14 @@ export const NETWORKS = {
   },
   chronos: {
     name: 'Chronos Testnet',
+    networkId: 'chronos' as const,
     rpc: {
       consensus: 'wss://rpc.chronos.autonomys.xyz/ws',
       autoEvm: 'wss://auto-evm.chronos.autonomys.xyz/ws',
     },
+    evmRpcHttp: 'https://auto-evm.chronos.autonomys.xyz/ws',
+    evmChainId: 8700,
+    domainId: 0,
     indexer: 'https://indexer-api.chronos.autonomys.xyz/v1/xdm',
     explorers: {
       consensus: 'https://autonomys-chronos.subscan.io',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,17 @@
       "name": "autonomys-helpers",
       "version": "0.1.0",
       "dependencies": {
+        "@autonomys/auto-utils": "^1.6.9",
+        "@autonomys/auto-wallet": "^1.6.9",
+        "@autonomys/auto-xdm": "^1.6.9",
         "@polkadot/api": "^15.8.1",
         "bootstrap": "^5.3.3",
+        "ethers": "^6.16.0",
         "next": "15.4.8",
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -24,6 +29,61 @@
         "eslint-config-next": "15.2.3",
         "gh-pages": "^6.3.0",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@autonomys/auto-consensus": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-consensus/-/auto-consensus-1.6.9.tgz",
+      "integrity": "sha512-juwI06/V7ku1B1koA3egPYvNS/I8NSUE6acOBnGkOHWCcJ/lu8faslQX/dlkp6UIm68t2Yy3nLlFblg63Ra5sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@autonomys/auto-utils": "^1.6.9",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@autonomys/auto-utils": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-utils/-/auto-utils-1.6.9.tgz",
+      "integrity": "sha512-NuLwNnMSckYv3OdkbGg02zfmHKZUWH0GL8mBf+HKCNJ3HHGHCThY0SjiHDlXCyjlW5YZ53DACvToPDZSN27mDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@polkadot/api": "^15.8.1",
+        "@polkadot/extension-dapp": "^0.58.6"
+      }
+    },
+    "node_modules/@autonomys/auto-wallet": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-wallet/-/auto-wallet-1.6.9.tgz",
+      "integrity": "sha512-1opH317dVJnnP3m3prEOTVRo53r4qe14l1Gjr4+slXM6Reeh10LwUh9KikBEf8QFyACT7YOWzedk1xZnEm25xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@autonomys/auto-utils": "^1.6.9",
+        "@talismn/connect-wallets": "^1.2.8",
+        "zustand": "^5.0.0"
+      }
+    },
+    "node_modules/@autonomys/auto-xdm": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-xdm/-/auto-xdm-1.6.9.tgz",
+      "integrity": "sha512-w0O3ITx3xP8j9K62S8AEmHMnIKoNvKTEMW6IAbfxJEuOXb+yVirUPl8rFe+YeIAJi/zJ/xK6KJB9PC9DjgbA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@autonomys/auto-consensus": "^1.6.9",
+        "@autonomys/auto-utils": "^1.6.9"
+      },
+      "peerDependencies": {
+        "ethers": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ethers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -899,12 +959,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -914,9 +974,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1046,25 +1106,25 @@
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-15.8.1.tgz",
-      "integrity": "sha512-J4BhtTGoBYTLEtd6CMku8J7oKfv66elVd5IRF7yOddJFmY0zb5fNk3B2Y9Pv495fo77M0qKc/LjseCZn207pQQ==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-15.10.2.tgz",
+      "integrity": "sha512-UM/510TwdugPjMpfyhhMNOZJ3M2ftRk0Ftxe+WSWev3o1u0dxqGuIN6fN0c224CHXIr58uWXUoMRHi6Cnfaxhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api-augment": "15.8.1",
-        "@polkadot/api-base": "15.8.1",
-        "@polkadot/api-derive": "15.8.1",
-        "@polkadot/keyring": "^13.4.3",
-        "@polkadot/rpc-augment": "15.8.1",
-        "@polkadot/rpc-core": "15.8.1",
-        "@polkadot/rpc-provider": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-augment": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/types-create": "15.8.1",
-        "@polkadot/types-known": "15.8.1",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
+        "@polkadot/api-augment": "15.10.2",
+        "@polkadot/api-base": "15.10.2",
+        "@polkadot/api-derive": "15.10.2",
+        "@polkadot/keyring": "^13.4.4",
+        "@polkadot/rpc-augment": "15.10.2",
+        "@polkadot/rpc-core": "15.10.2",
+        "@polkadot/rpc-provider": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-augment": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/types-create": "15.10.2",
+        "@polkadot/types-known": "15.10.2",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
         "eventemitter3": "^5.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
@@ -1074,17 +1134,17 @@
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-15.8.1.tgz",
-      "integrity": "sha512-xVnkhaG9g2+uMx5ekvUb1Q5JDo1wzWVNhOAmGshAYuNmaQPupMTJIZ301/+gmw+23cvZd9/uCNZKF9x+wEWmOw==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-15.10.2.tgz",
+      "integrity": "sha512-CCli5ltPiJEyQF/8DmTRpTfYKHY4W0B+xQDmzKgFmd+Q64Qot0fGpsaZXZftef1Tuoh0Uqak9qM+6B4APXIPkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api-base": "15.8.1",
-        "@polkadot/rpc-augment": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-augment": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/api-base": "15.10.2",
+        "@polkadot/rpc-augment": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-augment": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1092,14 +1152,14 @@
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-15.8.1.tgz",
-      "integrity": "sha512-rGdasatpT5skvn49bc5qUB+oT2SyYeYWgnzGK1nc1UdOEEmV9/xMsBOqVc6KJsJR9vqnv9Y9SL00Bb9H21uVAA==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-15.10.2.tgz",
+      "integrity": "sha512-7DJw++5IbPrsLPGcTlIZbMOretfvQJG80CW8+A+t2BLxbbv+I2neWNQ9QV9O28XsbOHzNgKHXuRyirdaG/dvrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-core": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/rpc-core": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1108,19 +1168,19 @@
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-15.8.1.tgz",
-      "integrity": "sha512-/rN63eWMkVdJamkpmX00xmg3VTfCUgOXIjob1e1no6WkZsk1uAHaU90Scv4bQEIxhhewwFMIseMP8l8GlCsNHg==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-15.10.2.tgz",
+      "integrity": "sha512-tF9DZvdm7hkRIJ1HtJzu73vdqQWBr8935YSN/RNsRb4FhJK5cHaC2uB4NLdRMnyUjmH0JRSnvWFq+HHcVxFJZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "15.8.1",
-        "@polkadot/api-augment": "15.8.1",
-        "@polkadot/api-base": "15.8.1",
-        "@polkadot/rpc-core": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
+        "@polkadot/api": "15.10.2",
+        "@polkadot/api-augment": "15.10.2",
+        "@polkadot/api-base": "15.10.2",
+        "@polkadot/rpc-core": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1128,31 +1188,1214 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/keyring": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.4.3.tgz",
-      "integrity": "sha512-2ePNcvBTznDN2luKbZM5fdxgAnj7V8m276qSTgrHlqKVvg9FsQpRCR6CAU+AjhnHzpe7uiZO+UH+jlXWefI3AA==",
+    "node_modules/@polkadot/extension-dapp": {
+      "version": "0.58.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/extension-dapp/-/extension-dapp-0.58.10.tgz",
+      "integrity": "sha512-5R+Nt0IK9pC3QpO/Wf6GE63P7dYvnmf/Slj7HEZxYFoFgjiem7c21uT5D8X0WebHSuCweN0/nSzaZm6AuXfdPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "13.4.3",
-        "@polkadot/util-crypto": "13.4.3",
+        "@polkadot/extension-inject": "0.58.10",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/api": "*",
+        "@polkadot/util": "*",
+        "@polkadot/util-crypto": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-dapp/node_modules/@polkadot/extension-inject": {
+      "version": "0.58.10",
+      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.58.10.tgz",
+      "integrity": "sha512-bjZR/iFtRrQ+YIB1eYzvLWf/N2p1F9N9PcfmvL4z5nIHKZGftmPg18Pg0o3nvGwewjUDYw/YspZHu2NDo9Sslw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "^15.10.2",
+        "@polkadot/rpc-provider": "^15.10.2",
+        "@polkadot/types": "^15.10.2",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
+        "@polkadot/x-global": "^13.4.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/api": "*",
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject": {
+      "version": "0.62.6",
+      "resolved": "https://registry.npmjs.org/@polkadot/extension-inject/-/extension-inject-0.62.6.tgz",
+      "integrity": "sha512-CC7OS2WwUqEqQwORHehT6+fvS9KzFXtzoRsKLfo1yfWXUgcGMI4VYSMGKEX9sllktkvuc0ww4Ct5NIygsGNf2w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/api": "^16.5.3",
+        "@polkadot/rpc-provider": "^16.5.3",
+        "@polkadot/types": "^16.5.3",
+        "@polkadot/util": "^13.5.9",
+        "@polkadot/util-crypto": "^13.5.9",
+        "@polkadot/x-global": "^13.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/api": "*",
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.4.tgz",
+      "integrity": "sha512-mX1fwtXCBAHXEyZLSnSrMDGP+jfU2rr7GfDVQBz0cBY1nmY8N34RqPWGrZWj8o4DxVu1DQ91sGncOmlBwEl0Qg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/api-augment": "16.5.4",
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/api-derive": "16.5.4",
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/rpc-provider": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/types-known": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-augment": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.4.tgz",
+      "integrity": "sha512-9FTohz13ih458V2JBFjRACKHPqfM6j4bmmTbcSaE7hXcIOYzm4ABFo7xq5osLyvItganjsICErL2vRn2zULycw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-augment/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-augment/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-base": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.4.tgz",
+      "integrity": "sha512-V69v3ieg5+91yRUCG1vFRSLr7V7MvHPvo/QrzleIUu8tPXWldJ0kyXbWKHVNZEpVBA9LpjGvII+MHUW7EaKMNg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-base/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-base/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.4.tgz",
+      "integrity": "sha512-0JP2a6CaqTviacHsmnUKF4VLRsKdYOzQCqdL9JpwY/QBz/ZLqIKKPiSRg285EVLf8n/hWdTfxbWqQCsRa5NL+Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/api": "16.5.4",
+        "@polkadot/api-augment": "16.5.4",
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.1.tgz",
+      "integrity": "sha512-Cu7AKUzBTsUkbOtyuNzXcTpDjR9QW0fVR56o3gBmzfUCmvO1vlsuGzmmPzqpHymQQ3rrfqV78CPs62EGhw0R+A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.1",
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-randomvalues": "14.0.1",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.4.3",
-        "@polkadot/util-crypto": "13.4.3"
+        "@polkadot/util": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api-derive/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.1.tgz",
+      "integrity": "sha512-/XkQcvshzJLHITuPrN3zmQKuFIPdKWoaiHhhVLD6rQWV60lTXA3ajw3ocju8ZN7xRxnweMS9Ce0kMPYa0NhRMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.1.tgz",
+      "integrity": "sha512-Cu7AKUzBTsUkbOtyuNzXcTpDjR9QW0fVR56o3gBmzfUCmvO1vlsuGzmmPzqpHymQQ3rrfqV78CPs62EGhw0R+A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.1",
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-randomvalues": "14.0.1",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/api/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.1.tgz",
+      "integrity": "sha512-/XkQcvshzJLHITuPrN3zmQKuFIPdKWoaiHhhVLD6rQWV60lTXA3ajw3ocju8ZN7xRxnweMS9Ce0kMPYa0NhRMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.1.tgz",
+      "integrity": "sha512-kHydQPCeTvJrMC9VQO8LPhAhTUxzxfNF1HEknhZDBPPsxP/XpkYsEy/Ln1QzJmQqD5VsgwzLDE6cExbJ2CT9CA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/util-crypto": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/util-crypto": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.1.tgz",
+      "integrity": "sha512-Cu7AKUzBTsUkbOtyuNzXcTpDjR9QW0fVR56o3gBmzfUCmvO1vlsuGzmmPzqpHymQQ3rrfqV78CPs62EGhw0R+A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.1",
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-randomvalues": "14.0.1",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/keyring/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.1.tgz",
+      "integrity": "sha512-/XkQcvshzJLHITuPrN3zmQKuFIPdKWoaiHhhVLD6rQWV60lTXA3ajw3ocju8ZN7xRxnweMS9Ce0kMPYa0NhRMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.1.tgz",
+      "integrity": "sha512-wGlBtXDkusRAj4P7uxfPz80gLO1+j99MLBaQi3bEym2xrFrFhgIWVHOZlBit/1PfaBjhX2Z8XjRxaM2w1p7w2w==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "14.0.1",
+        "@substrate/ss58-registry": "^1.51.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/networks/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-augment": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.4.tgz",
+      "integrity": "sha512-j9v3Ttqv/EYGezHtVksGJAFZhE/4F7LUWooOazh/53ATowMby3lZUdwInrK6bpYmG2whmYMw/Fo283fwDroBtQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-augment/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-core": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.4.tgz",
+      "integrity": "sha512-92LOSTWujPjtmKOPvfCPs8rAaPFU+18wTtkIzwPwKxvxkN/SWsYSGIxmsoags9ramyHB6jp7Lr59TEuGMxIZzQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/rpc-provider": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-core/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-core/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.4.tgz",
+      "integrity": "sha512-mNAIBRA3jMvpnHsuqAX4InHSIqBdgxFD6ayVUFFAzOX8Fh6Xpd4RdI1dqr6a1pCzjnPSby4nbg+VuadWwauVtg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-support": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
+        "@polkadot/x-fetch": "^14.0.1",
+        "@polkadot/x-global": "^14.0.1",
+        "@polkadot/x-ws": "^14.0.1",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.11"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.1.tgz",
+      "integrity": "sha512-Cu7AKUzBTsUkbOtyuNzXcTpDjR9QW0fVR56o3gBmzfUCmvO1vlsuGzmmPzqpHymQQ3rrfqV78CPs62EGhw0R+A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.1",
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-randomvalues": "14.0.1",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/rpc-provider/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.1.tgz",
+      "integrity": "sha512-/XkQcvshzJLHITuPrN3zmQKuFIPdKWoaiHhhVLD6rQWV60lTXA3ajw3ocju8ZN7xRxnweMS9Ce0kMPYa0NhRMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.4.tgz",
+      "integrity": "sha512-8Oo1QWaL0DkIc/n2wKBIozPWug/0b2dPVhL+XrXHxJX7rIqS0x8sXDRbM9r166sI0nTqJiUho7pRIkt2PR/DMQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-augment": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.4.tgz",
+      "integrity": "sha512-AGjXR+Q9O9UtVkGw/HuOXlbRqVpvG6H8nr+taXP71wuC6RD9gznFBFBqoNkfWHD2w89esNVQLTvXHVxlLpTXqA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-augment/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-augment/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-codec": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.4.tgz",
+      "integrity": "sha512-OQtT1pmJu2F3/+Vh1OiXifKoeRy+CU1+Lu7dgTcdO705dnxU4447Zup5JVCJDnxBmMITts/38vbFN2pD225AnA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/x-bigint": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-codec/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-codec/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-create": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.4.tgz",
+      "integrity": "sha512-URQnvr/sgvgIRSxIW3lmml6HMSTRRj2hTZIm6nhMTlYSVT4rLWx0ZbYUAjoPBbaJ+BmoqZ6Bbs+tA+5cQViv5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-create/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-create/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-known": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.4.tgz",
+      "integrity": "sha512-Dd59y4e3AFCrH9xiqMU4xlG5+Zy0OTy7GQvqJVYXZFyAH+4HYDlxXjJGcSidGAmJcclSYfS3wyEkfw+j1EOVEw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/networks": "^14.0.1",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-known/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-known/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-support": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.4.tgz",
+      "integrity": "sha512-Ra6keCaO73ibxN6MzA56jFq9EReje7jjE4JQfzV5IpyDZdXcmPyJiEfa2Yps/YSP13Gc2e38t9FFyVau0V+SFQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/util": "^14.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-support/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types-support/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types/node_modules/@polkadot/util": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.1.tgz",
+      "integrity": "sha512-764HhxkPV3x5rM0/p6QdynC2dw26n+SaE+jisjx556ViCd4E28Ke4xSPef6C0Spy4aoXf2gt0PuLEcBvd6fVZg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-global": "14.0.1",
+        "@polkadot/x-textdecoder": "14.0.1",
+        "@polkadot/x-textencoder": "14.0.1",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.1.tgz",
+      "integrity": "sha512-Cu7AKUzBTsUkbOtyuNzXcTpDjR9QW0fVR56o3gBmzfUCmvO1vlsuGzmmPzqpHymQQ3rrfqV78CPs62EGhw0R+A==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "14.0.1",
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "14.0.1",
+        "@polkadot/x-randomvalues": "14.0.1",
+        "@scure/base": "^1.1.7",
+        "@scure/sr25519": "^0.2.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/types/node_modules/@polkadot/x-randomvalues": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.1.tgz",
+      "integrity": "sha512-/XkQcvshzJLHITuPrN3zmQKuFIPdKWoaiHhhVLD6rQWV60lTXA3ajw3ocju8ZN7xRxnweMS9Ce0kMPYa0NhRMg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "14.0.1",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-bigint": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.1.tgz",
+      "integrity": "sha512-gfozjGnebr2rqURs31KtaWumbW4rRZpbiluhlmai6luCNrf5u8pB+oLA35kPEntrsLk9PnIG9OsC/n4hEtx4OQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-bigint/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-fetch": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.1.tgz",
+      "integrity": "sha512-yFsnO0xfkp3bIcvH70ZvmeUINYH1YnjOIS1B430f3w6axkqKhAOWCgzzKGMSRgn4dtm3YgwMBKPQ4nyfIsGOJQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-fetch/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textdecoder": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.1.tgz",
+      "integrity": "sha512-CcWiPCuPVJsNk4Vq43lgFHqLRBQHb4r9RD7ZIYgmwoebES8TNm4g2ew9ToCzakFKSpzKu6I07Ne9wv/dt5zLuw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textencoder": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.1.tgz",
+      "integrity": "sha512-VY51SpQmF1ccmAGLfxhYnAe95Spfz049WZ/+kK4NfsGF9WejxVdU53Im5C80l45r8qHuYQsCWU3+t0FNunh2Kg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-ws": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.1.tgz",
+      "integrity": "sha512-Q18hoSuOl7F4aENNGNt9XYxkrjwZlC6xye9OQrPDeHam1SrvflGv9mSZHyo+mwJs0z1PCz2STpPEN9PKfZvHng==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@polkadot/x-global": "14.0.1",
+        "tslib": "^2.8.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/extension-inject/node_modules/@polkadot/x-ws/node_modules/@polkadot/x-global": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.1.tgz",
+      "integrity": "sha512-aCI44DJU4fU0XXqrrSGIpi7JrZXK2kpe0jaQ2p6oDVXOOYEnZYXnMhTTmBE1lF/xtxzX50MnZrrU87jziU0qbA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.9.tgz",
+      "integrity": "sha512-bMCpHDN7U8ytxawjBZ89/he5s3AmEZuOdkM/ABcorh/flXNPfyghjFK27Gy4OKoFxX52yJ2sTHR4NxM87GuFXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.4.3.tgz",
-      "integrity": "sha512-Z+YZkltBt//CtkVH8ZYJ1z66qYxdI0yPamzkzZAqw6gj3gjgSxKtxB4baA/rcAw05QTvN2R3dLkkmKr2mnHovQ==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
+      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "13.4.3",
+        "@polkadot/util": "13.5.9",
         "@substrate/ss58-registry": "^1.51.0",
         "tslib": "^2.8.0"
       },
@@ -1161,15 +2404,15 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-15.8.1.tgz",
-      "integrity": "sha512-Ko5VVQYkifnEiSkuq0vwxjwTdlgsexn8lcB2zzpDIdq1SVF/w3/lg7Ln4hqPKJ4QGAYf1D5sqhZCbOhlgN+DfA==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-15.10.2.tgz",
+      "integrity": "sha512-9QQ8utyAEdEl7iScteIN59EBu8eNZjZa8AfKBitbdq1Hezd+WPil5LdoYi+wmJOMhZHeDT1s7/j2+kY1Z2Vymg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-core": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/rpc-core": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1177,15 +2420,15 @@
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-15.8.1.tgz",
-      "integrity": "sha512-QnEULlLO+eNVChll6nx8/J+VAa1SHmIZKi/ahMM5A5UWGc0ntLNDRT3Ts5itpUW8zI0mHCuQlkS1/7nYgbCb+Q==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-15.10.2.tgz",
+      "integrity": "sha512-vqDvr1WcHH3WPzDV4WTlf2S5cDmIoFPciynJ8eNcKqR3mG7Cqd0iL+MG6s0KFXdSY2Qvtl+0C6yZN0xr4Ha6BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-augment": "15.8.1",
-        "@polkadot/rpc-provider": "15.8.1",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/rpc-augment": "15.10.2",
+        "@polkadot/rpc-provider": "15.10.2",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1194,19 +2437,19 @@
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-15.8.1.tgz",
-      "integrity": "sha512-EAIRYiZNQeGPgG6AFyuRQdqLrYB/BL01Ra4ES8LA9nZwS4BVXuMoyzNuQqExUe2gNOjFfyVqURNBCR/0xzhMQg==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-15.10.2.tgz",
+      "integrity": "sha512-kqpPW8U0stVW+uOZP8g5d87Xb8rbXJR5PUub6xgGG6AOMbbvvuCU3GSohu/iozo4p9uD7TGH90jvbxj1rjJVMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/keyring": "^13.4.3",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-support": "15.8.1",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
-        "@polkadot/x-fetch": "^13.4.3",
-        "@polkadot/x-global": "^13.4.3",
-        "@polkadot/x-ws": "^13.4.3",
+        "@polkadot/keyring": "^13.4.4",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-support": "15.10.2",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
+        "@polkadot/x-fetch": "^13.4.4",
+        "@polkadot/x-global": "^13.4.4",
+        "@polkadot/x-ws": "^13.4.4",
         "eventemitter3": "^5.0.1",
         "mock-socket": "^9.3.1",
         "nock": "^13.5.5",
@@ -1220,17 +2463,17 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-15.8.1.tgz",
-      "integrity": "sha512-PALHaxeMaR+KwVN15XdmkF5udL9nm8ysIoS3iDMTSjjmZAZVhoELSUam/VxwEYkIuFBADj0i3zJTsEbiWBHotg==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-15.10.2.tgz",
+      "integrity": "sha512-/wDwKdDijxSXyNk5YezhVitdFxoQaTSSG9KXa7dEWujtmS/51UHmt9+P3W8b8D8kKaCvumahf/ww3GJI6s0Eqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/keyring": "^13.4.3",
-        "@polkadot/types-augment": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/types-create": "15.8.1",
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/util-crypto": "^13.4.3",
+        "@polkadot/keyring": "^13.4.4",
+        "@polkadot/types-augment": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/types-create": "15.10.2",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/util-crypto": "^13.4.4",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1239,14 +2482,14 @@
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-15.8.1.tgz",
-      "integrity": "sha512-g3i+0q03gCLEx8YWDcvQk39QBAl4Cj59njNyX9XQKS2WZY0ZLVD4TMw0HEozMnYBb23dJjNeFxHkIdSQzaJBKA==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-15.10.2.tgz",
+      "integrity": "sha512-X/xh+Dzud6OIyr7q8xttAwn+Fb5hKImIWEO1oG8WcInqv+P0vRyu7Tds+2ut9t64sJi3ydJ7I+T+WxZYheCU7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1254,13 +2497,13 @@
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-15.8.1.tgz",
-      "integrity": "sha512-F5GMDbxCeBCBM28gwnMMXvf0psU1j6NL9HG7KzlxWV7sjz/GwOEVyzETaSTrp4/wXt5QYUIGJiFG4ltzkx9K4g==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-15.10.2.tgz",
+      "integrity": "sha512-dhwbaukUZiYDW3QAAnLAFThYE5hQGdwBMWOVTt9+aBWxEKovLK93j0V30tEzMUtrZy8xaRWdhdDeQ3DSmxEP6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "^13.4.3",
-        "@polkadot/x-bigint": "^13.4.3",
+        "@polkadot/util": "^13.4.4",
+        "@polkadot/x-bigint": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1268,13 +2511,13 @@
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-15.8.1.tgz",
-      "integrity": "sha512-h/4v5QJmagOjp3qFtBx+KQV5J8GxR/SJae1RTEt/6gCl/p9mS+yFGHHJ+ihD1wvcvh9XZCf/yotJAh+romY16A==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-15.10.2.tgz",
+      "integrity": "sha512-vqXwPUSgx/By31qSkhOR5GN6zMbF1MkiX3F1g5KKHaRE8p/DdTry4LhufxhtK1mr9eBWvVGXxCOZdwjQco2M1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1282,16 +2525,16 @@
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-15.8.1.tgz",
-      "integrity": "sha512-0kNMRN2xd4aQybKT7sFrjOId7SOtry4z6BYg97mqNVf42ZH4idk3YKO41RA2nfyzOuuFzr6hav4FrRa+8Aue0w==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-15.10.2.tgz",
+      "integrity": "sha512-vs02WiIlLualrrh/EuA5qzK6QzatVPqBBNqa66dUtmyhJy48OEelBK+QLfOIQvZKU0ModEunoVrnxuY+O1DCmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/networks": "^13.4.3",
-        "@polkadot/types": "15.8.1",
-        "@polkadot/types-codec": "15.8.1",
-        "@polkadot/types-create": "15.8.1",
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/networks": "^13.4.4",
+        "@polkadot/types": "15.10.2",
+        "@polkadot/types-codec": "15.10.2",
+        "@polkadot/types-create": "15.10.2",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1299,12 +2542,12 @@
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-15.8.1.tgz",
-      "integrity": "sha512-2NWhxdD7+rARlnKiFo83+wtjzAT4tvaZUD7ahxTukJbHSewpwhaHpqnCJccasw51qipI4rX0G1ytPJbI4NIRDg==",
+      "version": "15.10.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-15.10.2.tgz",
+      "integrity": "sha512-sHamH6MehJa7aGZ/DHTB6vJAhSN5VrJx5lpDpb3xgBFTr0cVc5IsociqgJ/mgvyEIdLF3laraPxREqxCmuxTaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "^13.4.3",
+        "@polkadot/util": "^13.4.4",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1312,15 +2555,15 @@
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.4.3.tgz",
-      "integrity": "sha512-6v2zvg8l7W22XvjYf7qv9tPQdYl2E6aXY94M4TZKsXZxmlS5BoG+A9Aq0+Gw8zBUjupjEmUkA6Y//msO8Zisug==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
+      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-bigint": "13.4.3",
-        "@polkadot/x-global": "13.4.3",
-        "@polkadot/x-textdecoder": "13.4.3",
-        "@polkadot/x-textencoder": "13.4.3",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-global": "13.5.9",
+        "@polkadot/x-textdecoder": "13.5.9",
+        "@polkadot/x-textencoder": "13.5.9",
         "@types/bn.js": "^5.1.6",
         "bn.js": "^5.2.1",
         "tslib": "^2.8.0"
@@ -1330,19 +2573,19 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.4.3.tgz",
-      "integrity": "sha512-Ml0mjhKVetMrRCIosmVNMa6lbFPa3fSAeOggf34NsDIIQOKt9FL644iGz1ZSMOnBwN9qk2qHYmcFMTDXX2yKVQ==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
+      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.4.3",
-        "@polkadot/util": "13.4.3",
-        "@polkadot/wasm-crypto": "^7.4.1",
-        "@polkadot/wasm-util": "^7.4.1",
-        "@polkadot/x-bigint": "13.4.3",
-        "@polkadot/x-randomvalues": "13.4.3",
+        "@polkadot/networks": "13.5.9",
+        "@polkadot/util": "13.5.9",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-randomvalues": "13.5.9",
         "@scure/base": "^1.1.7",
         "tslib": "^2.8.0"
       },
@@ -1350,16 +2593,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.4.3"
+        "@polkadot/util": "13.5.9"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.4.1.tgz",
-      "integrity": "sha512-tdkJaV453tezBxhF39r4oeG0A39sPKGDJmN81LYLf+Fihb7astzwju+u75BRmDrHZjZIv00un3razJEWCxze6g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-util": "7.4.1",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1371,16 +2614,16 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.4.1.tgz",
-      "integrity": "sha512-kHN/kF7hYxm1y0WeFLWeWir6oTzvcFmR4N8fJJokR+ajYbdmrafPN+6iLgQVbhZnDdxyv9jWDuRRsDnBx8tPMQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.4.1",
-        "@polkadot/wasm-crypto-asmjs": "7.4.1",
-        "@polkadot/wasm-crypto-init": "7.4.1",
-        "@polkadot/wasm-crypto-wasm": "7.4.1",
-        "@polkadot/wasm-util": "7.4.1",
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1392,9 +2635,9 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.4.1.tgz",
-      "integrity": "sha512-pwU8QXhUW7IberyHJIQr37IhbB6DPkCG5FhozCiNTq4vFBsFPjm9q8aZh7oX1QHQaiAZa2m2/VjIVE+FHGbvHQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.7.0"
@@ -1407,15 +2650,15 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.4.1.tgz",
-      "integrity": "sha512-AVka33+f7MvXEEIGq5U0dhaA2SaXMXnxVCQyhJTaCnJ5bRDj0Xlm3ijwDEQUiaDql7EikbkkRtmlvs95eSUWYQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.4.1",
-        "@polkadot/wasm-crypto-asmjs": "7.4.1",
-        "@polkadot/wasm-crypto-wasm": "7.4.1",
-        "@polkadot/wasm-util": "7.4.1",
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1427,12 +2670,12 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.4.1.tgz",
-      "integrity": "sha512-PE1OAoupFR0ZOV2O8tr7D1FEUAwaggzxtfs3Aa5gr+yxlSOaWUKeqsOYe1KdrcjmZVV3iINEAXxgrbzCmiuONg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-util": "7.4.1",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1443,9 +2686,9 @@
       }
     },
     "node_modules/@polkadot/wasm-util": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.4.1.tgz",
-      "integrity": "sha512-RAcxNFf3zzpkr+LX/ItAsvj+QyM56TomJ0xjUMo4wKkHjwsxkz4dWJtx5knIgQz/OthqSDMR59VNEycQeNuXzA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.7.0"
@@ -1458,12 +2701,12 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.4.3.tgz",
-      "integrity": "sha512-8NbjF5Q+5lflhvDFve58wULjCVcvXa932LKFtI5zL2gx5VDhMgyfkNcYRjHB18Ecl21963JuGzvGVTZNkh/i6g==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
+      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1471,12 +2714,12 @@
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.4.3.tgz",
-      "integrity": "sha512-EwhcwROqWa7mvNTbLVNH71Hbyp5PW5j9lV2UpII5MZzRO95eYwV4oP/xgtTxC+60nC8lrvzAw0JxEHrmNzmtlg==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.5.9.tgz",
+      "integrity": "sha512-urwXQZtT4yYROiRdJS6zHu18J/jCoAGpbgPIAjwdqjT11t9XIq4SjuPMxD19xBRhbYe9ocWV8i1KHuoMbZgKbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "node-fetch": "^3.3.2",
         "tslib": "^2.8.0"
       },
@@ -1485,9 +2728,9 @@
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.4.3.tgz",
-      "integrity": "sha512-6c98kxZdoGRct3ua9Dz6/qz8wb3XFRUkaY+4+RzIgehKMPhu19pGWTrzmbJSyY9FtIpThuWKuDaBEvd5KgSxjA==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1497,29 +2740,29 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.4.3.tgz",
-      "integrity": "sha512-pskXP/S2jROZ6aASExsUFlNp7GbJvQikKogvyvMMCzNIbUYLxpLuquLRa3MOORx2c0SNsENg90cx/zHT+IjPRQ==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
+      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.4.3",
+        "@polkadot/util": "13.5.9",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.4.3.tgz",
-      "integrity": "sha512-k7Wg6csAPxfNtpBt3k5yUuPHYmRl/nl7H2OMr40upMjbZXbQ1RJW9Z3GBkLmQczG7NwwfAXHwQE9FYOMUtbuRQ==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
+      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1527,12 +2770,12 @@
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.4.3.tgz",
-      "integrity": "sha512-byl2LbN1rnEXKmnsCzEDaIjSIHAr+1ciSe2yj3M0K+oWEEcaFZEovJaf/uoyzkcjn+/l8rDv3nget6mPuQ/DSw==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
+      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1540,12 +2783,12 @@
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.4.3.tgz",
-      "integrity": "sha512-GS0I6MYLD/xNAAjODZi/pbG7Ba0e/5sbvDIrT01iKH3SPGN+PZoyAsc04t2IOXA6QmPa1OBHnaU3N4K8gGmJ+w==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.5.9.tgz",
+      "integrity": "sha512-NKVgvACTIvKT8CjaQu9d0dERkZsWIZngX/4NVSjc01WHmln4F4y/zyBdYn/Z2V0Zw28cISx+lB4qxRmqTe7gbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.4.3",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0",
         "ws": "^8.18.0"
       },
@@ -1655,6 +2898,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/sr25519": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
+      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "~1.9.2",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@substrate/connect": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
@@ -1715,6 +2972,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@talismn/connect-wallets": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@talismn/connect-wallets/-/connect-wallets-1.2.8.tgz",
+      "integrity": "sha512-/aniEZxOUNOaOEctHDUb/1jNFgKNsmeQ3L+pm4KvfYqb+C3HjZeBxykHEIc+5xmdR0GgCm30N8QzYWv6voM/lQ==",
+      "license": "GPL-3.0",
+      "peerDependencies": {
+        "@polkadot/api": ">=9.3.3",
+        "@polkadot/extension-inject": ">=0.44.6"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2222,6 +3489,12 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -3556,6 +4829,94 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/eventemitter3": {
@@ -4961,6 +6322,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "funding": [
         {
           "type": "github",
@@ -6643,6 +8005,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@autonomys/auto-utils": "^1.6.9",
+    "@autonomys/auto-wallet": "^1.6.9",
+    "@autonomys/auto-xdm": "^1.6.9",
     "@polkadot/api": "^15.8.1",
     "bootstrap": "^5.3.3",
+    "ethers": "^6.16.0",
     "next": "15.4.8",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ export default function Home() {
     <div className="container py-5">
       <h1>Autonomys Helpers</h1>
       <ul className="mt-4">
+        <li><Link href="/xdm/send">Send XDM Transfer</Link></li>
         <li><Link href="/xdm/channels">View XDM Channel Status</Link></li>
         <li><Link href="/xdm/transfers">View XDM Transfer Status</Link></li>
       </ul>

--- a/pages/xdm/send.tsx
+++ b/pages/xdm/send.tsx
@@ -77,7 +77,12 @@ export default function SendPage() {
       router.push(`/xdm/transfers?search=${encodeURIComponent(searchAddr)}&network=${selectedNetwork}`);
     } catch (err) {
       console.error('Transfer failed:', err);
-      const message = err instanceof Error ? err.message : 'Transfer failed. Please try again.';
+      const raw = err instanceof Error ? err.message : String(err);
+      // Detect user rejection from wallet
+      const isRejected = /user rejected|cancelled|action_rejected|rejected by user/i.test(raw);
+      const message = isRejected
+        ? 'Transaction was rejected in your wallet.'
+        : raw || 'Transfer failed. Please try again.';
       setSubmitError(message);
     } finally {
       setIsSubmitting(false);

--- a/pages/xdm/send.tsx
+++ b/pages/xdm/send.tsx
@@ -164,7 +164,7 @@ export default function SendPage() {
       <SendForm
         direction={direction}
         network={selectedNetwork}
-        senderAddress={isEvmWrongChain ? null : senderAddress}
+        senderAddress={!isConsensusToEvm && isEvmWrongChain ? null : senderAddress}
         evmProvider={evmWallet.provider}
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}

--- a/pages/xdm/send.tsx
+++ b/pages/xdm/send.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import { ButtonGroup, ToggleButton } from 'react-bootstrap';
+import NetworkSelector from '../../components/NetworkSelector';
+import SubstrateWalletConnect from '../../components/wallet/SubstrateWalletConnect';
+import EvmWalletConnect from '../../components/wallet/EvmWalletConnect';
+import SendForm from '../../components/SendForm';
+import { useSubstrateWallet } from '../../components/wallet/useSubstrateWallet';
+import { useEvmWallet } from '../../components/wallet/useEvmWallet';
+import { NETWORKS, type NetworkType } from '../../config/networks';
+import {
+  transferConsensusToEvm,
+  transferEvmToConsensus,
+  type TransferDirection,
+} from '../../utils/xdmTransfer';
+
+const DIRECTIONS: { value: TransferDirection; label: string }[] = [
+  { value: 'consensus-to-evm', label: 'Consensus → Auto EVM' },
+  { value: 'evm-to-consensus', label: 'Auto EVM → Consensus' },
+];
+
+export default function SendPage() {
+  const router = useRouter();
+  const [selectedNetwork, setSelectedNetwork] = useState<NetworkType>('mainnet');
+  const [direction, setDirection] = useState<TransferDirection>('consensus-to-evm');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const substrateWallet = useSubstrateWallet();
+  const evmWallet = useEvmWallet();
+
+  const isConsensusToEvm = direction === 'consensus-to-evm';
+  const networkConfig = NETWORKS[selectedNetwork];
+
+  // Determine sender address based on direction
+  const senderAddress = isConsensusToEvm
+    ? substrateWallet.selectedAccount?.address ?? null
+    : evmWallet.address;
+
+  const handleSwitchEvmChain = useCallback(async () => {
+    await evmWallet.switchChain(
+      networkConfig.evmChainId,
+      `Autonomys ${networkConfig.name} Auto EVM`,
+      networkConfig.evmRpcHttp,
+    );
+  }, [evmWallet, networkConfig]);
+
+  const handleSubmit = useCallback(async (recipient: string, amountAi3: string) => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      if (isConsensusToEvm) {
+        if (!substrateWallet.injector || !substrateWallet.selectedAccount) {
+          throw new Error('Substrate wallet not connected');
+        }
+        await transferConsensusToEvm({
+          network: selectedNetwork,
+          injector: substrateWallet.injector,
+          senderAddress: substrateWallet.selectedAccount.address,
+          recipientEvmAddress: recipient,
+          amountAi3,
+        });
+      } else {
+        if (!evmWallet.signer) {
+          throw new Error('EVM wallet not connected');
+        }
+        await transferEvmToConsensus({
+          signer: evmWallet.signer,
+          recipientSs58Address: recipient,
+          amountAi3,
+        });
+      }
+
+      // Redirect to transfers page to track progress
+      const searchAddr = senderAddress ?? '';
+      router.push(`/xdm/transfers?search=${encodeURIComponent(searchAddr)}&network=${selectedNetwork}`);
+    } catch (err) {
+      console.error('Transfer failed:', err);
+      const message = err instanceof Error ? err.message : 'Transfer failed. Please try again.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [isConsensusToEvm, substrateWallet, evmWallet, selectedNetwork, senderAddress, router]);
+
+  const isEvmWrongChain = evmWallet.isConnected && evmWallet.chainId !== networkConfig.evmChainId;
+
+  return (
+    <div className="container py-3 py-md-5" style={{ maxWidth: 640 }}>
+      <h1 className="fs-3">Send XDM Transfer</h1>
+      <p className="text-muted mb-4">
+        Transfer AI3 tokens between the Consensus chain and Auto EVM domain.
+      </p>
+
+      <NetworkSelector
+        selectedNetwork={selectedNetwork}
+        onChange={setSelectedNetwork}
+      />
+
+      <div className="mb-4">
+        <label className="form-label fw-bold">Transfer Direction:</label>
+        <ButtonGroup className="w-100">
+          {DIRECTIONS.map((d) => (
+            <ToggleButton
+              key={d.value}
+              id={`dir-${d.value}`}
+              type="radio"
+              variant={direction === d.value ? 'primary' : 'outline-primary'}
+              name="directionToggle"
+              value={d.value}
+              checked={direction === d.value}
+              onChange={() => {
+                setDirection(d.value);
+                setSubmitError(null);
+              }}
+            >
+              {d.label}
+            </ToggleButton>
+          ))}
+        </ButtonGroup>
+      </div>
+
+      <div className="mb-4">
+        <label className="form-label fw-bold">
+          {isConsensusToEvm ? 'Substrate Wallet (Source):' : 'EVM Wallet (Source):'}
+        </label>
+        {isConsensusToEvm ? (
+          <SubstrateWalletConnect
+            isConnected={substrateWallet.isConnected}
+            isLoading={substrateWallet.isLoading}
+            connectionError={substrateWallet.connectionError}
+            selectedAccount={substrateWallet.selectedAccount}
+            accounts={substrateWallet.accounts}
+            availableWallets={substrateWallet.availableWallets}
+            onConnect={substrateWallet.connectWallet}
+            onDisconnect={substrateWallet.disconnectWallet}
+            onSelectAccount={substrateWallet.selectAccount}
+            onClearError={substrateWallet.clearError}
+          />
+        ) : (
+          <EvmWalletConnect
+            isConnected={evmWallet.isConnected}
+            isLoading={evmWallet.isLoading}
+            address={evmWallet.address}
+            chainId={evmWallet.chainId}
+            expectedChainId={networkConfig.evmChainId}
+            expectedChainName={`Autonomys ${networkConfig.name} Auto EVM`}
+            error={evmWallet.error}
+            isMetaMaskInstalled={evmWallet.isMetaMaskInstalled}
+            onConnect={evmWallet.connect}
+            onDisconnect={evmWallet.disconnect}
+            onSwitchChain={handleSwitchEvmChain}
+            onClearError={evmWallet.clearError}
+          />
+        )}
+      </div>
+
+      <SendForm
+        direction={direction}
+        network={selectedNetwork}
+        senderAddress={isEvmWrongChain ? null : senderAddress}
+        evmProvider={evmWallet.provider}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        submitError={submitError}
+      />
+    </div>
+  );
+}

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -1,0 +1,125 @@
+import { activate, disconnect, signAndSendTx, ai3ToShannons } from '@autonomys/auto-utils';
+import type { SignerOptions } from '@autonomys/auto-utils';
+import { transporterTransfer, transferToConsensus } from '@autonomys/auto-xdm';
+import type { InjectedExtension } from '@polkadot/extension-inject/types';
+import type { JsonRpcSigner, BrowserProvider } from 'ethers';
+import type { NetworkType } from '../config/networks';
+import { NETWORKS } from '../config/networks';
+
+export type TransferDirection = 'consensus-to-evm' | 'evm-to-consensus';
+
+export interface TransferResult {
+  success: boolean;
+  txHash?: string;
+  blockNumber?: number;
+  error?: string;
+}
+
+/**
+ * Execute a Consensus → Auto EVM transfer using the Substrate wallet.
+ */
+export async function transferConsensusToEvm(params: {
+  network: NetworkType;
+  injector: InjectedExtension;
+  senderAddress: string;
+  recipientEvmAddress: string;
+  amountAi3: string;
+}): Promise<TransferResult> {
+  const { network, injector, senderAddress, recipientEvmAddress, amountAi3 } = params;
+  const config = NETWORKS[network];
+
+  const api = await activate({ networkId: config.networkId });
+  try {
+    const amount = ai3ToShannons(amountAi3);
+    const tx = transporterTransfer(
+      api,
+      { domainId: config.domainId },
+      { accountId20: recipientEvmAddress },
+      amount,
+    );
+
+    // Cast signer to work around @polkadot version mismatch between extension-inject and auto-utils
+    const result = await signAndSendTx(senderAddress, tx, { signer: injector.signer } as Partial<SignerOptions>);
+    return {
+      success: result.success,
+      txHash: result.txHash,
+    };
+  } finally {
+    await disconnect(api);
+  }
+}
+
+/**
+ * Execute an Auto EVM → Consensus transfer using the EVM precompile.
+ * Fetches current fee data to avoid "gas price less than block base fee" errors.
+ */
+export async function transferEvmToConsensus(params: {
+  signer: JsonRpcSigner;
+  recipientSs58Address: string;
+  amountAi3: string;
+}): Promise<TransferResult> {
+  const { signer, recipientSs58Address, amountAi3 } = params;
+  const amount = ai3ToShannons(amountAi3);
+
+  // Fetch current fee data so the tx meets the block base fee
+  const provider = signer.provider;
+  const feeData = await provider.getFeeData();
+
+  const result = await transferToConsensus(signer, recipientSs58Address, amount, {
+    maxFeePerGas: feeData.maxFeePerGas ?? undefined,
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas ?? undefined,
+  });
+  return {
+    success: result.success,
+    txHash: result.transactionHash,
+    blockNumber: result.blockNumber,
+  };
+}
+
+/**
+ * Fetch the balance of a Substrate account on the consensus chain.
+ * Returns balance in AI3 as a string.
+ */
+export async function getConsensusBalance(
+  network: NetworkType,
+  address: string,
+): Promise<string> {
+  const config = NETWORKS[network];
+  const api = await activate({ networkId: config.networkId });
+  try {
+    const accountInfo = await api.query.system.account(address);
+    const free = (accountInfo as unknown as { data: { free: { toBigInt: () => bigint } } }).data.free.toBigInt();
+    // Convert from Shannons to AI3 (18 decimals)
+    const ai3 = Number(free) / 1e18;
+    return ai3.toFixed(4);
+  } finally {
+    await disconnect(api);
+  }
+}
+
+/**
+ * Fetch the balance of an EVM account on the Auto EVM domain.
+ * Returns balance in AI3 as a string.
+ */
+export async function getEvmBalance(provider: BrowserProvider, address: string): Promise<string> {
+  const balance = await provider.getBalance(address);
+  // balance is in wei (18 decimals) — same as AI3 Shannons
+  const ai3 = Number(balance) / 1e18;
+  return ai3.toFixed(4);
+}
+
+/**
+ * Basic address format validation.
+ */
+export function isValidEvmAddress(addr: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(addr);
+}
+
+export function isValidSubstrateAddress(addr: string): boolean {
+  // Substrate addresses are base58 encoded, typically 46-48 chars
+  // Starting with a character (not 0x)
+  if (addr.startsWith('0x')) return false;
+  if (addr.length < 40 || addr.length > 60) return false;
+  // Basic base58 character check
+  return /^[1-9A-HJ-NP-Za-km-z]+$/.test(addr);
+}

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -1,5 +1,4 @@
-import { activate, disconnect, signAndSendTx, ai3ToShannons } from '@autonomys/auto-utils';
-import type { SignerOptions } from '@autonomys/auto-utils';
+import { activate, disconnect, ai3ToShannons } from '@autonomys/auto-utils';
 import { transporterTransfer, transferToConsensus } from '@autonomys/auto-xdm';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';
 import type { JsonRpcSigner, BrowserProvider } from 'ethers';
@@ -17,6 +16,8 @@ export interface TransferResult {
 
 /**
  * Execute a Consensus → Auto EVM transfer using the Substrate wallet.
+ * Uses tx.signAndSend() directly (rather than the SDK's signAndSendTx) so that
+ * wallet rejections properly reject the promise instead of hanging forever.
  */
 export async function transferConsensusToEvm(params: {
   network: NetworkType;
@@ -38,14 +39,51 @@ export async function transferConsensusToEvm(params: {
       amount,
     );
 
-    // Cast signer to work around @polkadot version mismatch between extension-inject and auto-utils
-    const result = await signAndSendTx(senderAddress, tx, { signer: injector.signer } as Partial<SignerOptions>);
-    return {
-      success: result.success,
-      txHash: result.txHash,
-    };
+    // We use two racing promises:
+    // 1. The status-callback promise that resolves/rejects based on tx lifecycle
+    // 2. The signAndSend outer promise that rejects if the wallet denies signing
+    //
+    // Some wallet extensions (e.g. SubWallet) reject the outer promise while
+    // others may throw synchronously or fire the callback with an error.
+    // Racing both + wrapping in try/catch covers all paths.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await new Promise<TransferResult>((resolve, reject) => {
+      let settled = false;
+      const safeResolve = (v: TransferResult) => { if (!settled) { settled = true; resolve(v); } };
+      const safeReject = (e: unknown) => { if (!settled) { settled = true; reject(e); } };
+
+      try {
+        const outerPromise = tx.signAndSend(
+          senderAddress,
+          { signer: injector.signer as any },
+          ({ status, txHash, dispatchError }) => {
+            if (dispatchError) {
+              safeReject(new Error(`Transaction failed: ${dispatchError.toString()}`));
+            } else if (status.isInBlock || status.isFinalized) {
+              safeResolve({
+                success: true,
+                txHash: txHash.toHex(),
+              });
+            } else if (status.isDropped || status.isInvalid || status.isRetracted) {
+              safeReject(new Error('Transaction was dropped or invalid.'));
+            }
+          },
+        );
+        // The outer promise rejects when the wallet denies the signing request.
+        // Attach .catch so this rejection settles our wrapper promise.
+        if (outerPromise && typeof (outerPromise as any).catch === 'function') {
+          (outerPromise as any).catch(safeReject);
+        }
+      } catch (err) {
+        // Synchronous throw from signAndSend (some extension implementations)
+        safeReject(err);
+      }
+    });
+
+    return result;
   } finally {
-    await disconnect(api);
+    // disconnect in background — don't let it block error propagation
+    disconnect(api).catch((e) => console.warn('Failed to disconnect API:', e));
   }
 }
 

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -2,7 +2,7 @@ import { activate, disconnect, ai3ToShannons } from '@autonomys/auto-utils';
 import { transporterTransfer, transferToConsensus } from '@autonomys/auto-xdm';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';
 import { decodeAddress } from '@polkadot/keyring';
-import { isAddress as isValidEthersAddress, getAddress } from 'ethers';
+import { isAddress as isValidEthersAddress } from 'ethers';
 import type { JsonRpcSigner, BrowserProvider } from 'ethers';
 import type { NetworkType } from '../config/networks';
 import { NETWORKS } from '../config/networks';
@@ -51,8 +51,17 @@ export async function transferConsensusToEvm(params: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await new Promise<TransferResult>((resolve, reject) => {
       let settled = false;
-      const safeResolve = (v: TransferResult) => { if (!settled) { settled = true; resolve(v); } };
-      const safeReject = (e: unknown) => { if (!settled) { settled = true; reject(e); } };
+      let unsub: (() => void) | undefined;
+
+      const cleanup = () => {
+        if (unsub) { try { unsub(); } catch { /* ignore */ } }
+      };
+      const safeResolve = (v: TransferResult) => {
+        if (!settled) { settled = true; cleanup(); resolve(v); }
+      };
+      const safeReject = (e: unknown) => {
+        if (!settled) { settled = true; cleanup(); reject(e); }
+      };
 
       try {
         const outerPromise = tx.signAndSend(
@@ -71,10 +80,13 @@ export async function transferConsensusToEvm(params: {
             }
           },
         );
-        // The outer promise rejects when the wallet denies the signing request.
-        // Attach .catch so this rejection settles our wrapper promise.
-        if (outerPromise && typeof (outerPromise as any).catch === 'function') {
-          (outerPromise as any).catch(safeReject);
+        // The outer promise resolves to an unsubscribe fn on success,
+        // but rejects if the wallet denies the signing request.
+        if (outerPromise && typeof (outerPromise as any).then === 'function') {
+          (outerPromise as any).then(
+            (fn: unknown) => { if (typeof fn === 'function') unsub = fn as () => void; },
+            safeReject,
+          );
         }
       } catch (err) {
         // Synchronous throw from signAndSend (some extension implementations)
@@ -153,17 +165,6 @@ export async function getEvmBalance(provider: BrowserProvider, address: string):
  */
 export function isValidEvmAddress(addr: string): boolean {
   return isValidEthersAddress(addr);
-}
-
-/**
- * Return the EIP-55 checksummed version of an EVM address, or null if invalid.
- */
-export function checksumEvmAddress(addr: string): string | null {
-  try {
-    return getAddress(addr);
-  } catch {
-    return null;
-  }
 }
 
 export function isValidSubstrateAddress(addr: string): boolean {

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -1,6 +1,8 @@
 import { activate, disconnect, ai3ToShannons } from '@autonomys/auto-utils';
 import { transporterTransfer, transferToConsensus } from '@autonomys/auto-xdm';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';
+import { decodeAddress } from '@polkadot/keyring';
+import { isAddress as isValidEthersAddress, getAddress } from 'ethers';
 import type { JsonRpcSigner, BrowserProvider } from 'ethers';
 import type { NetworkType } from '../config/networks';
 import { NETWORKS } from '../config/networks';
@@ -147,17 +149,28 @@ export async function getEvmBalance(provider: BrowserProvider, address: string):
 }
 
 /**
- * Basic address format validation.
+ * Validate an EVM address using ethers.js (includes EIP-55 checksum validation).
  */
 export function isValidEvmAddress(addr: string): boolean {
-  return /^0x[0-9a-fA-F]{40}$/.test(addr);
+  return isValidEthersAddress(addr);
+}
+
+/**
+ * Return the EIP-55 checksummed version of an EVM address, or null if invalid.
+ */
+export function checksumEvmAddress(addr: string): string | null {
+  try {
+    return getAddress(addr);
+  } catch {
+    return null;
+  }
 }
 
 export function isValidSubstrateAddress(addr: string): boolean {
-  // Substrate addresses are base58 encoded, typically 46-48 chars
-  // Starting with a character (not 0x)
-  if (addr.startsWith('0x')) return false;
-  if (addr.length < 40 || addr.length > 60) return false;
-  // Basic base58 character check
-  return /^[1-9A-HJ-NP-Za-km-z]+$/.test(addr);
+  try {
+    decodeAddress(addr);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `/xdm/send` page for initiating cross-domain AI3 token transfers
- **Consensus → Auto EVM**: Substrate wallet connection (Talisman/SubWallet/Polkadot.js) via `@autonomys/auto-xdm` `transporterTransfer()`
- **Auto EVM → Consensus**: MetaMask connection via EVM transporter precompile with ethers.js
- Post-transfer redirect to `/xdm/transfers` for progress tracking

## New files
- `pages/xdm/send.tsx` — Main send page with network/direction selector, wallet connection, transfer form
- `components/wallet/useSubstrateWallet.ts` — Hook wrapping `@autonomys/auto-wallet` Zustand store
- `components/wallet/useEvmWallet.ts` — Hook for MetaMask via `window.ethereum` + ethers.js
- `components/wallet/SubstrateWalletConnect.tsx` — Bootstrap wallet picker UI
- `components/wallet/EvmWalletConnect.tsx` — Bootstrap MetaMask connection UI
- `components/SendForm.tsx` — Transfer form with balance display, validation, confirmation modal
- `utils/xdmTransfer.ts` — Transfer execution wrapping Auto SDK functions

## Modified files
- `config/networks.ts` — Added `networkId`, `evmChainId` (870/8700), `domainId`, `evmRpcHttp`
- `pages/index.tsx` — Added link to send page
- `package.json` — Added `@autonomys/auto-wallet`, `@autonomys/auto-xdm`, `@autonomys/auto-utils`, `ethers`, `zustand`

## Design notes
- Wallet hooks and UI components are separated (hook provides state, component renders it) for future portability to Tailwind or other CSS frameworks
- Uses Auto SDK's `activate()`/`disconnect()` for Substrate API connections
- Fetches EVM fee data before submitting to avoid base fee errors

## Test plan
- [x] Test Consensus → Auto EVM transfer with Substrate wallet
- [x] Test Auto EVM → Consensus transfer with MetaMask
- [x] Test wrong-chain detection and network switching for EVM
- [x] Test address validation (EVM and Substrate formats)
- [x] Test balance display and MAX button
- [x] Verify redirect to transfers page after successful send
- [x] Test on both Mainnet and Chronos Testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new token-transfer and wallet-connection paths (signing, chain switching, fee/gas handling) that can fail in edge cases or misconfiguration, but is largely additive and isolated to the new send feature.
> 
> **Overview**
> Adds a new `/xdm/send` flow to initiate cross-domain AI3 transfers, including direction toggle (**Consensus → Auto EVM** vs **Auto EVM → Consensus**), network selection, and post-send redirect to `/xdm/transfers` for tracking.
> 
> Introduces new wallet connection UI + hooks for Substrate extensions (via `@autonomys/auto-wallet`/Zustand) and MetaMask (via `ethers`), plus a `SendForm` with balance fetching, address/amount validation, MAX amount, and a confirmation modal.
> 
> Implements transfer execution helpers in `utils/xdmTransfer.ts` (Substrate `signAndSend` handling to correctly surface wallet rejections; EVM transfer with fee-data-based gas settings) and extends `config/networks.ts` with EVM chain metadata (`networkId`, `evmChainId`, `evmRpcHttp`, `domainId`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560472d62f2835e034569d9cdf591dfe77183149. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->