### PR TITLE
fix: use SDK signAndSendTx for Consensus → EVM transfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "autonomys-helpers",
       "version": "0.1.0",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.9",
-        "@autonomys/auto-wallet": "^1.6.9",
-        "@autonomys/auto-xdm": "^1.6.9",
+        "@autonomys/auto-utils": "^1.6.10",
+        "@autonomys/auto-wallet": "^1.6.10",
+        "@autonomys/auto-xdm": "^1.6.10",
         "@polkadot/api": "^15.8.1",
         "bootstrap": "^5.3.3",
         "ethers": "^6.16.0",
@@ -38,19 +38,19 @@
       "license": "MIT"
     },
     "node_modules/@autonomys/auto-consensus": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-consensus/-/auto-consensus-1.6.9.tgz",
-      "integrity": "sha512-juwI06/V7ku1B1koA3egPYvNS/I8NSUE6acOBnGkOHWCcJ/lu8faslQX/dlkp6UIm68t2Yy3nLlFblg63Ra5sw==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-consensus/-/auto-consensus-1.6.10.tgz",
+      "integrity": "sha512-SMTQ3EYwR9cMV5/36yiYOA25K2YDBXa23gExpNWUhN9mBRBhcZA2TDHCta8D5993UU8+2k+rNtlHja4ILPk9Og==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.9",
+        "@autonomys/auto-utils": "^1.6.10",
         "zod": "^3.24.2"
       }
     },
     "node_modules/@autonomys/auto-utils": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-utils/-/auto-utils-1.6.9.tgz",
-      "integrity": "sha512-NuLwNnMSckYv3OdkbGg02zfmHKZUWH0GL8mBf+HKCNJ3HHGHCThY0SjiHDlXCyjlW5YZ53DACvToPDZSN27mDg==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-utils/-/auto-utils-1.6.10.tgz",
+      "integrity": "sha512-SoWiWs7B+fIsm2+WYLt/50iDsNZkmKaxr2ET3s1rBX23VO+cAUOXA+2bmqxUhhxy9uV6AU1r0Op3dwnT1zv4GQ==",
       "license": "MIT",
       "dependencies": {
         "@polkadot/api": "^15.8.1",
@@ -58,24 +58,24 @@
       }
     },
     "node_modules/@autonomys/auto-wallet": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-wallet/-/auto-wallet-1.6.9.tgz",
-      "integrity": "sha512-1opH317dVJnnP3m3prEOTVRo53r4qe14l1Gjr4+slXM6Reeh10LwUh9KikBEf8QFyACT7YOWzedk1xZnEm25xw==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-wallet/-/auto-wallet-1.6.10.tgz",
+      "integrity": "sha512-NrTZXoj8bhu6lNf3ZzBNzN7j3U+OGLwTgQJNQn4CKaR8cIWBR7QvnnhxiTc4274C08DHtrIVlCdUSiXyCFlhtw==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.9",
+        "@autonomys/auto-utils": "^1.6.10",
         "@talismn/connect-wallets": "^1.2.8",
         "zustand": "^5.0.0"
       }
     },
     "node_modules/@autonomys/auto-xdm": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-xdm/-/auto-xdm-1.6.9.tgz",
-      "integrity": "sha512-w0O3ITx3xP8j9K62S8AEmHMnIKoNvKTEMW6IAbfxJEuOXb+yVirUPl8rFe+YeIAJi/zJ/xK6KJB9PC9DjgbA3A==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-xdm/-/auto-xdm-1.6.10.tgz",
+      "integrity": "sha512-TxNHFOtWVZQCKaE9pXNqpzBDJKoMmUwv/cSbEbzDojR9MO02qjrzRzG5T+QiZM1Z5eXesGyfP5ApkIcBmZZNYA==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-consensus": "^1.6.9",
-        "@autonomys/auto-utils": "^1.6.9"
+        "@autonomys/auto-consensus": "^1.6.10",
+        "@autonomys/auto-utils": "^1.6.10"
       },
       "peerDependencies": {
         "ethers": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@autonomys/auto-utils": "^1.6.9",
-    "@autonomys/auto-wallet": "^1.6.9",
-    "@autonomys/auto-xdm": "^1.6.9",
+    "@autonomys/auto-utils": "^1.6.10",
+    "@autonomys/auto-wallet": "^1.6.10",
+    "@autonomys/auto-xdm": "^1.6.10",
     "@polkadot/api": "^15.8.1",
     "bootstrap": "^5.3.3",
     "ethers": "^6.16.0",

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -1,4 +1,4 @@
-import { activate, disconnect, ai3ToShannons } from '@autonomys/auto-utils';
+import { activate, disconnect, ai3ToShannons, signAndSendTx } from '@autonomys/auto-utils';
 import { transporterTransfer, transferToConsensus } from '@autonomys/auto-xdm';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';
 import { decodeAddress } from '@polkadot/keyring';
@@ -18,8 +18,8 @@ export interface TransferResult {
 
 /**
  * Execute a Consensus → Auto EVM transfer using the Substrate wallet.
- * Uses tx.signAndSend() directly (rather than the SDK's signAndSendTx) so that
- * wallet rejections properly reject the promise instead of hanging forever.
+ * Uses signAndSendTx from @autonomys/auto-utils (≥1.6.10), which correctly
+ * handles wallet rejection, subscription cleanup, and success detection.
  */
 export async function transferConsensusToEvm(params: {
   network: NetworkType;
@@ -41,62 +41,11 @@ export async function transferConsensusToEvm(params: {
       amount,
     );
 
-    // We use two racing promises:
-    // 1. The status-callback promise that resolves/rejects based on tx lifecycle
-    // 2. The signAndSend outer promise that rejects if the wallet denies signing
-    //
-    // Some wallet extensions (e.g. SubWallet) reject the outer promise while
-    // others may throw synchronously or fire the callback with an error.
-    // Racing both + wrapping in try/catch covers all paths.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await new Promise<TransferResult>((resolve, reject) => {
-      let settled = false;
-      let unsub: (() => void) | undefined;
+    const result = await signAndSendTx(senderAddress, tx, { signer: injector.signer as any });
 
-      const cleanup = () => {
-        if (unsub) { try { unsub(); } catch { /* ignore */ } }
-      };
-      const safeResolve = (v: TransferResult) => {
-        if (!settled) { settled = true; cleanup(); resolve(v); }
-      };
-      const safeReject = (e: unknown) => {
-        if (!settled) { settled = true; cleanup(); reject(e); }
-      };
-
-      try {
-        const outerPromise = tx.signAndSend(
-          senderAddress,
-          { signer: injector.signer as any },
-          ({ status, txHash, dispatchError }) => {
-            if (dispatchError) {
-              safeReject(new Error(`Transaction failed: ${dispatchError.toString()}`));
-            } else if (status.isInBlock || status.isFinalized) {
-              safeResolve({
-                success: true,
-                txHash: txHash.toHex(),
-              });
-            } else if (status.isDropped || status.isInvalid || status.isRetracted) {
-              safeReject(new Error('Transaction was dropped or invalid.'));
-            }
-          },
-        );
-        // The outer promise resolves to an unsubscribe fn on success,
-        // but rejects if the wallet denies the signing request.
-        if (outerPromise && typeof (outerPromise as any).then === 'function') {
-          (outerPromise as any).then(
-            (fn: unknown) => { if (typeof fn === 'function') unsub = fn as () => void; },
-            safeReject,
-          );
-        }
-      } catch (err) {
-        // Synchronous throw from signAndSend (some extension implementations)
-        safeReject(err);
-      }
-    });
-
-    return result;
+    return { success: result.success, txHash: result.txHash };
   } finally {
-    // disconnect in background — don't let it block error propagation
     disconnect(api).catch((e) => console.warn('Failed to disconnect API:', e));
   }
 }


### PR DESCRIPTION
Closes #11

## Summary

Removes the custom `signAndSend` implementation in `transferConsensusToEvm` and replaces it with `signAndSendTx` from `@autonomys/auto-utils`, as originally intended when issue #11 was filed.

### Background

When the XDM send feature was built in PR #10, the SDK's `signAndSendTx` had two bugs that prevented its use:

1. **Wallet rejection hung forever** — `signAndSendTx` didn't catch the rejection from `tx.signAndSend()` when a browser wallet (SubWallet, Talisman, Polkadot.js) denied the signing request. Fixed in [autonomys/auto-sdk#515](https://github.com/autonomys/auto-sdk/pull/515), released in v1.6.10.

2. **`detectTxSuccess` always returned `false`** — a `return true` inside `Array.forEach()` returned from the callback, not the function, so `result.success` was always `false`. Raised in [autonomys/auto-sdk#516](https://github.com/autonomys/auto-sdk/issues/516), fixed in [autonomys/auto-sdk#533](https://github.com/autonomys/auto-sdk/pull/533) (pending release).

### Changes

- **`utils/xdmTransfer.ts`** — Replace ~55 lines of manual promise wrangling (settled guard, `unsub` race, `safeResolve`/`safeReject`, synchronous-throw catch) with a single `signAndSendTx(...)` call.
- **`package.json`** — Bump all `@autonomys/*` dependencies from `^1.6.9` → `^1.6.10` to pick up the wallet-rejection fix.

### Note on `result.success`

`detectTxSuccess` is still broken in v1.6.10 (fix is in auto-sdk PR #533, not yet released). However, `signAndSendTx` resolves/rejects based on `validateEvents` (checking for `system.ExtrinsicSuccess`), not on `detectTxSuccess`, so promise resolution behaviour is correct. The `result.success` field returned to the caller will be `false` for successful transactions until the auto-sdk fix is released — but `send.tsx` discards the return value and uses try/catch for flow control, so this has no user-visible impact.

## Test plan

- [x] Connect SubWallet / Talisman, initiate a Consensus → Auto EVM transfer, **reject** in the wallet — spinner should stop and show rejection error
- [x] Complete a successful Consensus → Auto EVM transfer — should redirect to transfers page
- [x] Auto EVM → Consensus transfer unaffected