### PR TITLE
Don't change XDM amount when scrolling the wheel over the input

### DIFF
--- a/components/SendForm.tsx
+++ b/components/SendForm.tsx
@@ -205,6 +205,8 @@ const SendForm: React.FC<SendFormProps> = ({
                     setAmount(e.target.value);
                     setValidationError(null);
                   }}
+                  // Prevent the mouse wheel from changing the amount when the input is focused.
+                  onWheel={(e) => (e.target as HTMLInputElement).blur()}
                   disabled={isSubmitting}
                 />
                 <Button


### PR DESCRIPTION
## Summary
- Number inputs change value on mouse-wheel-scroll when focused. On the XDM send page this is easy to trigger by accident while scrolling the page, and silently changes the amount you're about to send.
- Fix: blur the input on `wheel`, so the wheel just scrolls.

Touches the shared `components/SendForm.tsx`, so both transfer directions (Consensus → Auto EVM and Auto EVM → Consensus) are covered in one place.

## Test plan
- [x] `npm run dev`, open `/xdm/send`
- [x] Focus the Amount field, type a value
- [x] Scroll the mouse wheel over the input — value should not change, page should scroll
- [x] Confirm the up/down arrow keys still work for fine-tuning while the input is focused
- [x] Repeat for both transfer directions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI event handler on a number input; no auth, API, or transfer logic changes.
> 
> **Overview**
> Prevents accidental send-amount changes when users scroll the page with the **Amount (AI3)** field focused. Focused `type="number"` inputs normally increment/decrement on mouse wheel, which is easy to trigger on the XDM send flow.
> 
> The shared **`SendForm`** amount field now blurs on **`wheel`**, so scrolling passes through to the page instead of mutating the value. Both transfer directions (Consensus ↔ Auto EVM) pick this up from the same component. Keyboard up/down for fine-tuning while focused is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f635d2aa3cb55b24e1ecbbe4153f2c3cf0e290. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->