### PR TITLE
Bump @autonomys/* to 1.6.14 and tidy stale version note

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "autonomys-helpers",
       "version": "0.1.0",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.10",
-        "@autonomys/auto-wallet": "^1.6.10",
-        "@autonomys/auto-xdm": "^1.6.10",
+        "@autonomys/auto-utils": "^1.6.14",
+        "@autonomys/auto-wallet": "^1.6.14",
+        "@autonomys/auto-xdm": "^1.6.14",
         "@polkadot/api": "^15.8.1",
         "bootstrap": "^5.3.3",
         "ethers": "^6.16.0",
@@ -38,19 +38,19 @@
       "license": "MIT"
     },
     "node_modules/@autonomys/auto-consensus": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-consensus/-/auto-consensus-1.6.10.tgz",
-      "integrity": "sha512-SMTQ3EYwR9cMV5/36yiYOA25K2YDBXa23gExpNWUhN9mBRBhcZA2TDHCta8D5993UU8+2k+rNtlHja4ILPk9Og==",
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-consensus/-/auto-consensus-1.6.14.tgz",
+      "integrity": "sha512-WVnVrRDT+9/ps4vHHCHeq8vsP/kV1udLkTtCV9y4d/pjMTQBkdIMU4559L7sk8jBASIprDME244TLVlc6qt0xg==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.10",
+        "@autonomys/auto-utils": "^1.6.14",
         "zod": "^3.24.2"
       }
     },
     "node_modules/@autonomys/auto-utils": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-utils/-/auto-utils-1.6.10.tgz",
-      "integrity": "sha512-SoWiWs7B+fIsm2+WYLt/50iDsNZkmKaxr2ET3s1rBX23VO+cAUOXA+2bmqxUhhxy9uV6AU1r0Op3dwnT1zv4GQ==",
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-utils/-/auto-utils-1.6.14.tgz",
+      "integrity": "sha512-D50DBBxKh1LB2uh6PRCYCNiJzf/TbQCSqe/NCIhwu7HX5znmx81Hdpe1TBNdQGh+yaYR/Y6ROF1JB/Y3LfBU7g==",
       "license": "MIT",
       "dependencies": {
         "@polkadot/api": "^15.8.1",
@@ -58,24 +58,24 @@
       }
     },
     "node_modules/@autonomys/auto-wallet": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-wallet/-/auto-wallet-1.6.10.tgz",
-      "integrity": "sha512-NrTZXoj8bhu6lNf3ZzBNzN7j3U+OGLwTgQJNQn4CKaR8cIWBR7QvnnhxiTc4274C08DHtrIVlCdUSiXyCFlhtw==",
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-wallet/-/auto-wallet-1.6.14.tgz",
+      "integrity": "sha512-MECTHZXyl+obBD2CYtB/BoePbr1GuGeoLxScRabwC0dXjq7goJCznLy9h4SBeLm6GAWt8Yu9RvX4857YQUBbKQ==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-utils": "^1.6.10",
+        "@autonomys/auto-utils": "^1.6.14",
         "@talismn/connect-wallets": "^1.2.8",
         "zustand": "^5.0.0"
       }
     },
     "node_modules/@autonomys/auto-xdm": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@autonomys/auto-xdm/-/auto-xdm-1.6.10.tgz",
-      "integrity": "sha512-TxNHFOtWVZQCKaE9pXNqpzBDJKoMmUwv/cSbEbzDojR9MO02qjrzRzG5T+QiZM1Z5eXesGyfP5ApkIcBmZZNYA==",
+      "version": "1.6.14",
+      "resolved": "https://registry.npmjs.org/@autonomys/auto-xdm/-/auto-xdm-1.6.14.tgz",
+      "integrity": "sha512-486UnviortJkIsOsoNUmPjLph37m+tKNlwHrYwSW5Q8+BqxG/mUCz2ZsSIHqGRlpTGYoxcVitz4T8B9BbaBEFw==",
       "license": "MIT",
       "dependencies": {
-        "@autonomys/auto-consensus": "^1.6.10",
-        "@autonomys/auto-utils": "^1.6.10"
+        "@autonomys/auto-consensus": "^1.6.14",
+        "@autonomys/auto-utils": "^1.6.14"
       },
       "peerDependencies": {
         "ethers": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@autonomys/auto-utils": "^1.6.10",
-    "@autonomys/auto-wallet": "^1.6.10",
-    "@autonomys/auto-xdm": "^1.6.10",
+    "@autonomys/auto-utils": "^1.6.14",
+    "@autonomys/auto-wallet": "^1.6.14",
+    "@autonomys/auto-xdm": "^1.6.14",
     "@polkadot/api": "^15.8.1",
     "bootstrap": "^5.3.3",
     "ethers": "^6.16.0",

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -18,8 +18,6 @@ export interface TransferResult {
 
 /**
  * Execute a Consensus → Auto EVM transfer using the Substrate wallet.
- * Uses signAndSendTx from @autonomys/auto-utils (≥1.6.10), which correctly
- * handles wallet rejection, subscription cleanup, and success detection.
  */
 export async function transferConsensusToEvm(params: {
   network: NetworkType;


### PR DESCRIPTION
## Summary
- Drop the stale \`Uses signAndSendTx from @autonomys/auto-utils (≥1.6.10), …\` doc comment from \`utils/xdmTransfer.ts\`. The rationale is captured in commit f96a107 / PR #13 and the version pin lives in \`package.json\`; the comment reads as a live caveat when it's really history.
- Bump \`@autonomys/auto-utils\`, \`@autonomys/auto-wallet\`, and \`@autonomys/auto-xdm\` from \`^1.6.10\` to \`^1.6.14\`. No source changes were needed to compile.

Note: I'd originally hoped the SDK bump would let us drop the \`as any\` cast on \`injector.signer\` in \`transferConsensusToEvm\`. It doesn't — that cast bridges two transitively-installed copies of \`@polkadot/types\` (15.x from \`@polkadot/api\`, 16.x via talisman's \`extension-inject\`), which is independent of the auto-* version.

## Test plan
- [x] \`npm install\` and verify lockfile diff looks reasonable
- [x] \`npx tsc --noEmit\` is clean (already verified locally)
- [x] Smoke-test an XDM transfer in both directions on Chronos

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDK bumps touch wallet and XDM paths used for real transfers, though there are no application logic edits beyond the comment.
> 
> **Overview**
> **Dependency bump:** `@autonomys/auto-utils`, `@autonomys/auto-wallet`, and `@autonomys/auto-xdm` are pinned from `^1.6.10` to `^1.6.14` in `package.json`, with the lockfile updated for the full `@autonomys/*` tree (including `auto-consensus`).
> 
> **Docs:** The JSDoc on `transferConsensusToEvm` no longer mentions `signAndSendTx` and the old `≥1.6.10` caveat; the comment now only states that the flow uses the Substrate wallet. Transfer code and the `injector.signer as any` cast are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc646f8692eefd9ad9beb80bd9d9b3fd1c4f54d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->