### PR TITLE
Add WAI3 wrapping / unwrapping interface

### DIFF
--- a/components/NetworkSelector.tsx
+++ b/components/NetworkSelector.tsx
@@ -5,9 +5,10 @@ import { NETWORKS, NetworkType } from '../config/networks';
 interface NetworkSelectorProps {
   selectedNetwork: NetworkType;
   onChange: (network: NetworkType) => void;
+  disabled?: boolean;
 }
 
-const NetworkSelector: React.FC<NetworkSelectorProps> = ({ selectedNetwork, onChange }) => {
+const NetworkSelector: React.FC<NetworkSelectorProps> = ({ selectedNetwork, onChange, disabled = false }) => {
   return (
     <div className="mb-4">
       <label className="form-label fw-bold">Select Network:</label>
@@ -21,6 +22,7 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({ selectedNetwork, onCh
             name="networkToggle"
             value={key}
             checked={selectedNetwork === key}
+            disabled={disabled}
             onChange={() => onChange(key)}
           >
             {NETWORKS[key].name}

--- a/components/wallet/useEvmWallet.ts
+++ b/components/wallet/useEvmWallet.ts
@@ -39,9 +39,15 @@ export function useEvmWallet(): EvmWalletState {
   const [signer, setSigner] = useState<JsonRpcSigner | null>(null);
   const [provider, setProvider] = useState<BrowserProvider | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Resolved after mount so server-rendered HTML doesn't disagree with client.
+  const [isMetaMaskInstalled, setIsMetaMaskInstalled] = useState(false);
   const mountedRef = useRef(true);
 
-  const isMetaMaskInstalled = typeof window !== 'undefined' && !!window.ethereum;
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.ethereum) {
+      setIsMetaMaskInstalled(true);
+    }
+  }, []);
 
   const clearError = useCallback(() => setError(null), []);
 

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -14,6 +14,8 @@ export const NETWORKS = {
       consensus: 'https://autonomys.subscan.io',
       autoEvm: 'https://explorer.auto-evm.mainnet.autonomys.xyz',
     },
+    nativeSymbol: 'AI3',
+    wai3Address: '0x7ba06C7374566c68495f7e4690093521F6B991bb',
   },
   chronos: {
     name: 'Chronos Testnet',
@@ -30,6 +32,8 @@ export const NETWORKS = {
       consensus: 'https://autonomys-chronos.subscan.io',
       autoEvm: 'https://explorer.auto-evm.chronos.autonomys.xyz',
     },
+    nativeSymbol: 'tAI3',
+    wai3Address: '0xeAb23556Ec571bA10F4C3C8051d719E58e921caC',
   },
 } as const;
 
@@ -73,3 +77,12 @@ export function getBlockExplorerUrl(
 // XDM confirmation depths in domain blocks
 export const CONSENSUS_TO_DOMAIN_DEPTH = 100;
 export const DOMAIN_TO_CONSENSUS_DEPTH = 14_400;
+
+/**
+ * Display name for the Auto EVM chain of a given network, e.g.
+ * "Autonomys Mainnet Auto EVM". Used when adding/switching the chain in a
+ * connected wallet.
+ */
+export function getEvmChainDisplayName(network: NetworkType): string {
+  return `Autonomys ${NETWORKS[network].name} Auto EVM`;
+}

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -15,6 +15,7 @@ export const NETWORKS = {
       autoEvm: 'https://explorer.auto-evm.mainnet.autonomys.xyz',
     },
     nativeSymbol: 'AI3',
+    wrappedSymbol: 'WAI3',
     wai3Address: '0x7ba06C7374566c68495f7e4690093521F6B991bb',
   },
   chronos: {
@@ -33,6 +34,10 @@ export const NETWORKS = {
       autoEvm: 'https://explorer.auto-evm.chronos.autonomys.xyz',
     },
     nativeSymbol: 'tAI3',
+    // The Chronos WAI3 contract reports symbol() = "WAI3" on-chain, not
+    // "WtAI3" - keep this matching what the contract actually returns so
+    // wallet_watchAsset registers a consistent symbol.
+    wrappedSymbol: 'WAI3',
     wai3Address: '0xeAb23556Ec571bA10F4C3C8051d719E58e921caC',
   },
 } as const;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,10 +4,17 @@ export default function Home() {
   return (
     <div className="container py-5">
       <h1>Autonomys Helpers</h1>
-      <ul className="mt-4">
+
+      <h2 className="fs-4 mt-4">XDM</h2>
+      <ul>
         <li><Link href="/xdm/send">Send XDM Transfer</Link></li>
         <li><Link href="/xdm/channels">View XDM Channel Status</Link></li>
         <li><Link href="/xdm/transfers">View XDM Transfer Status</Link></li>
+      </ul>
+
+      <h2 className="fs-4 mt-4">WAI3</h2>
+      <ul>
+        <li><Link href="/wrap">Wrap & Unwrap AI3 / WAI3</Link></li>
       </ul>
     </div>
   )

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -334,6 +334,8 @@ export default function WrapPage() {
                       setAmount(e.target.value);
                       setValidationError(null);
                     }}
+                    // Prevent the mouse wheel from changing the amount when the input is focused.
+                    onWheel={(e) => (e.target as HTMLInputElement).blur()}
                     disabled={isSubmitting}
                   />
                   <Button

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -70,6 +70,12 @@ export default function WrapPage() {
         }
       } catch (err) {
         console.error('Failed to fetch balances:', err);
+        // Clear stale balances so validation and MAX don't operate on
+        // figures that no longer match the current address / network.
+        if (!cancelled) {
+          setNativeBalance(null);
+          setWai3Balance(null);
+        }
       } finally {
         if (!cancelled) setBalanceLoading(false);
       }
@@ -88,6 +94,14 @@ export default function WrapPage() {
     setAddTokenStatus(null);
     setShowConfirm(false);
   }, [direction, selectedNetwork]);
+
+  // Close the confirm modal if the wallet's chain changes while it's open,
+  // so a user can't open it on the right chain, switch networks in the
+  // wallet, then submit a wrap/unwrap against the UI network with a signer
+  // on a different chain.
+  useEffect(() => {
+    setShowConfirm(false);
+  }, [evmWallet.chainId]);
 
   const sourceBalance = isWrap ? nativeBalance : wai3Balance;
   const sourceSymbol = isWrap ? nativeSymbol : wrappedSymbol;

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -1,0 +1,432 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Alert, Button, ButtonGroup, Card, Form, Modal, Spinner, ToggleButton } from 'react-bootstrap';
+import NetworkSelector from '../components/NetworkSelector';
+import EvmWalletConnect from '../components/wallet/EvmWalletConnect';
+import { useEvmWallet } from '../components/wallet/useEvmWallet';
+import { NETWORKS, getEvmChainDisplayName, type NetworkType } from '../config/networks';
+import { getEvmBalance } from '../utils/xdmTransfer';
+import { addWai3ToWallet, getWai3Balance, unwrapWai3, wrapAi3 } from '../utils/wai3';
+import { describeWalletError } from '../utils/walletErrors';
+
+type WrapDirection = 'wrap' | 'unwrap';
+
+function directionLabel(direction: WrapDirection, nativeSymbol: string, wrappedSymbol: string): string {
+  return direction === 'wrap'
+    ? `Wrap ${nativeSymbol} -> ${wrappedSymbol}`
+    : `Unwrap ${wrappedSymbol} -> ${nativeSymbol}`;
+}
+
+const DIRECTIONS: WrapDirection[] = ['wrap', 'unwrap'];
+
+const DOCS_URL = 'https://develop.autonomys.xyz/evm/wrapping_ai3';
+
+export default function WrapPage() {
+  const [selectedNetwork, setSelectedNetwork] = useState<NetworkType>('mainnet');
+  const [direction, setDirection] = useState<WrapDirection>('wrap');
+  const [amount, setAmount] = useState('');
+  const [nativeBalance, setNativeBalance] = useState<string | null>(null);
+  const [wai3Balance, setWai3Balance] = useState<string | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [addTokenStatus, setAddTokenStatus] = useState<string | null>(null);
+
+  const evmWallet = useEvmWallet();
+  const networkConfig = NETWORKS[selectedNetwork];
+  const nativeSymbol = networkConfig.nativeSymbol;
+  const wrappedSymbol = `W${nativeSymbol}`;
+  const isWrap = direction === 'wrap';
+  const isWrongChain = evmWallet.isConnected && evmWallet.chainId !== networkConfig.evmChainId;
+
+  const handleSwitchEvmChain = useCallback(async () => {
+    await evmWallet.switchChain(
+      networkConfig.evmChainId,
+      getEvmChainDisplayName(selectedNetwork),
+      networkConfig.evmRpcHttp,
+    );
+  }, [evmWallet, networkConfig]);
+
+  // Refresh balances when address, network or chain changes
+  useEffect(() => {
+    if (!evmWallet.address || !evmWallet.provider || isWrongChain) {
+      setNativeBalance(null);
+      setWai3Balance(null);
+      return;
+    }
+    let cancelled = false;
+    setBalanceLoading(true);
+    (async () => {
+      try {
+        const [native, wai3] = await Promise.all([
+          getEvmBalance(evmWallet.provider!, evmWallet.address!),
+          getWai3Balance(selectedNetwork, evmWallet.provider!, evmWallet.address!),
+        ]);
+        if (!cancelled) {
+          setNativeBalance(native);
+          setWai3Balance(wai3);
+        }
+      } catch (err) {
+        console.error('Failed to fetch balances:', err);
+      } finally {
+        if (!cancelled) setBalanceLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [evmWallet.address, evmWallet.provider, evmWallet.chainId, selectedNetwork, isWrongChain, txHash]);
+
+  // Reset form on direction/network change
+  useEffect(() => {
+    setAmount('');
+    setValidationError(null);
+    setSubmitError(null);
+    setTxHash(null);
+    setAddTokenStatus(null);
+  }, [direction, selectedNetwork]);
+
+  const sourceBalance = isWrap ? nativeBalance : wai3Balance;
+  const sourceSymbol = isWrap ? nativeSymbol : wrappedSymbol;
+  const targetSymbol = isWrap ? wrappedSymbol : nativeSymbol;
+
+  const validate = useCallback((): string | null => {
+    if (!amount.trim()) return 'Amount is required.';
+    const num = parseFloat(amount);
+    if (isNaN(num) || num <= 0) return 'Amount must be greater than 0.';
+    if (sourceBalance !== null && num > parseFloat(sourceBalance)) {
+      return `Insufficient ${sourceSymbol} balance.`;
+    }
+    return null;
+  }, [amount, sourceBalance, sourceSymbol]);
+
+  const handleSetMax = useCallback(() => {
+    if (sourceBalance === null) return;
+    if (isWrap) {
+      // leave a small buffer for gas
+      const max = Math.max(0, parseFloat(sourceBalance) - 0.01);
+      setAmount(max > 0 ? max.toFixed(4) : '0');
+    } else {
+      setAmount(sourceBalance);
+    }
+  }, [sourceBalance, isWrap]);
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+    const err = validate();
+    if (err) {
+      setValidationError(err);
+      return;
+    }
+    setValidationError(null);
+    setSubmitError(null);
+    setShowConfirm(true);
+  }, [validate]);
+
+  const handleConfirm = useCallback(async () => {
+    setShowConfirm(false);
+    if (!evmWallet.signer) {
+      setSubmitError('EVM wallet not connected.');
+      return;
+    }
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setTxHash(null);
+    try {
+      const result = isWrap
+        ? await wrapAi3({ network: selectedNetwork, signer: evmWallet.signer, amountAi3: amount.trim() })
+        : await unwrapWai3({ network: selectedNetwork, signer: evmWallet.signer, amountAi3: amount.trim() });
+      setTxHash(result.txHash);
+      setAmount('');
+    } catch (err) {
+      console.error('Transaction failed:', err);
+      setSubmitError(describeWalletError(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [evmWallet.signer, isWrap, selectedNetwork, amount]);
+
+  const handleAddNetwork = useCallback(async () => {
+    await evmWallet.switchChain(
+      networkConfig.evmChainId,
+      getEvmChainDisplayName(selectedNetwork),
+      networkConfig.evmRpcHttp,
+    );
+  }, [evmWallet, networkConfig]);
+
+  const handleAddToken = useCallback(async () => {
+    setAddTokenStatus(null);
+    const ok = await addWai3ToWallet(selectedNetwork);
+    setAddTokenStatus(
+      ok
+        ? `${wrappedSymbol} was added to your wallet.`
+        : `Could not add ${wrappedSymbol} - your wallet may not support this, or you declined.`,
+    );
+  }, [selectedNetwork, wrappedSymbol]);
+
+  const explorerBase = networkConfig.explorers.autoEvm;
+  const contractExplorerUrl = `${explorerBase}/address/${networkConfig.wai3Address}`;
+  const txExplorerUrl = txHash ? `${explorerBase}/tx/${txHash}` : null;
+
+  return (
+    <div className="container py-3 py-md-5" style={{ maxWidth: 720 }}>
+      <h1 className="fs-3">Wrap & Unwrap AI3</h1>
+      <p className="text-muted">
+        Convert native AI3 into the ERC-20 token <strong>WAI3</strong> (and back). WAI3 is a
+        WETH-style wrapper that lets AI3 be used in DeFi protocols, AMMs, and other
+        contracts that expect an ERC-20 interface.
+      </p>
+
+      <Card className="mb-4 border-info">
+        <Card.Body>
+          <Card.Title className="fs-6">Why wrap?</Card.Title>
+          <ul className="small mb-2">
+            <li>
+              <strong>Native AI3</strong> is the Auto EVM gas token - like ETH on Ethereum.
+              Most smart contracts can&apos;t accept it directly as a function argument.
+            </li>
+            <li>
+              <strong>WAI3</strong> is a standard ERC-20 backed 1:1 by native AI3 held in
+              the wrapper contract. Any ERC-20-aware contract can use it.
+            </li>
+            <li>
+              Wrapping locks AI3 in the contract and mints WAI3 to you. Unwrapping burns WAI3
+              and releases AI3 back to your account. The rate is always 1:1; no fees beyond gas.
+            </li>
+          </ul>
+          <a href={DOCS_URL} target="_blank" rel="noopener noreferrer" className="small">
+            Read the full docs
+          </a>
+        </Card.Body>
+      </Card>
+
+      <NetworkSelector selectedNetwork={selectedNetwork} onChange={setSelectedNetwork} />
+
+      <Card className="mb-4">
+        <Card.Body>
+          <div className="fw-bold mb-2">Step 1 - Prepare your wallet</div>
+          <p className="small text-muted mb-3">
+            Make sure the Auto EVM network is added to your wallet, and (optionally) add the
+            WAI3 token so it appears in your wallet&apos;s asset list.
+          </p>
+          <div className="d-flex flex-wrap gap-2">
+            <Button
+              variant="outline-primary"
+              size="sm"
+              onClick={handleAddNetwork}
+              disabled={!evmWallet.isMetaMaskInstalled}
+            >
+              Add {networkConfig.name} Auto EVM (chain {networkConfig.evmChainId})
+            </Button>
+            <Button
+              variant="outline-primary"
+              size="sm"
+              onClick={handleAddToken}
+              disabled={!evmWallet.isMetaMaskInstalled}
+            >
+              Add {wrappedSymbol} token to wallet
+            </Button>
+          </div>
+          {addTokenStatus && (
+            <div className="small text-muted mt-2">{addTokenStatus}</div>
+          )}
+          <div className="small text-muted mt-2">
+            WAI3 contract:{' '}
+            <a href={contractExplorerUrl} target="_blank" rel="noopener noreferrer" className="font-monospace">
+              {networkConfig.wai3Address}
+            </a>
+          </div>
+        </Card.Body>
+      </Card>
+
+      <div className="mb-3">
+        <label className="form-label fw-bold">Step 2 - Connect EVM wallet</label>
+        <EvmWalletConnect
+          isConnected={evmWallet.isConnected}
+          isLoading={evmWallet.isLoading}
+          address={evmWallet.address}
+          chainId={evmWallet.chainId}
+          expectedChainId={networkConfig.evmChainId}
+          expectedChainName={getEvmChainDisplayName(selectedNetwork)}
+          error={evmWallet.error}
+          isMetaMaskInstalled={evmWallet.isMetaMaskInstalled}
+          onConnect={evmWallet.connect}
+          onDisconnect={evmWallet.disconnect}
+          onSwitchChain={handleSwitchEvmChain}
+          onClearError={evmWallet.clearError}
+        />
+      </div>
+
+      <div className="mb-3">
+        <label className="form-label fw-bold">Step 3 - Choose direction</label>
+        <ButtonGroup className="w-100">
+          {DIRECTIONS.map((d) => (
+            <ToggleButton
+              key={d}
+              id={`wrap-dir-${d}`}
+              type="radio"
+              variant={direction === d ? 'primary' : 'outline-primary'}
+              name="wrapDirToggle"
+              value={d}
+              checked={direction === d}
+              onChange={() => setDirection(d)}
+            >
+              {directionLabel(d, nativeSymbol, wrappedSymbol)}
+            </ToggleButton>
+          ))}
+        </ButtonGroup>
+        <div className="small text-muted mt-2">
+          {isWrap ? (
+            <>
+              Wrapping calls the <code>payable</code> function{' '}
+              <code>deposit()</code> on the WAI3 contract, attaching the amount of{' '}
+              {nativeSymbol} as the transaction&apos;s <code>value</code>. The contract
+              holds the {nativeSymbol} and mints an equal amount of {wrappedSymbol} to you.
+            </>
+          ) : (
+            <>
+              Unwrapping calls <code>withdraw(uint256 amount)</code> on the WAI3 contract,
+              passing the amount as an argument. The contract burns your {wrappedSymbol}{' '}
+              and releases an equal amount of native {nativeSymbol} back to your address.
+            </>
+          )}
+        </div>
+      </div>
+
+      <Card>
+        <Card.Body>
+          <div className="fw-bold mb-2">Step 4 - Enter amount</div>
+          {!evmWallet.isConnected ? (
+            <div className="text-muted small">Connect your wallet above to continue.</div>
+          ) : isWrongChain ? (
+            <Alert variant="warning" className="py-2 small mb-0">
+              Switch your wallet to {networkConfig.name} Auto EVM to see balances.
+            </Alert>
+          ) : (
+            <Form onSubmit={handleSubmit}>
+              <div className="mb-3 small">
+                <div className="d-flex justify-content-between">
+                  <span className="text-muted">Native {nativeSymbol} balance:</span>
+                  <span className="font-monospace">
+                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (nativeBalance ?? '-')}
+                  </span>
+                </div>
+                <div className="d-flex justify-content-between">
+                  <span className="text-muted">{wrappedSymbol} balance:</span>
+                  <span className="font-monospace">
+                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (wai3Balance ?? '-')}
+                  </span>
+                </div>
+              </div>
+
+              <Form.Group className="mb-3">
+                <Form.Label className="fw-bold small">
+                  Amount ({sourceSymbol})
+                </Form.Label>
+                <div className="d-flex gap-2">
+                  <Form.Control
+                    type="number"
+                    step="any"
+                    min="0"
+                    placeholder="0.0"
+                    value={amount}
+                    onChange={(e) => {
+                      setAmount(e.target.value);
+                      setValidationError(null);
+                    }}
+                    disabled={isSubmitting}
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    size="sm"
+                    onClick={handleSetMax}
+                    disabled={sourceBalance === null || isSubmitting}
+                    className="flex-shrink-0"
+                  >
+                    MAX
+                  </Button>
+                </div>
+                <Form.Text className="text-muted">
+                  You will receive the same amount in {targetSymbol}.
+                </Form.Text>
+              </Form.Group>
+
+              {validationError && (
+                <Alert variant="warning" className="py-2 small">{validationError}</Alert>
+              )}
+              {submitError && (
+                <Alert variant="danger" className="py-2 small">{submitError}</Alert>
+              )}
+              {txHash && txExplorerUrl && (
+                <Alert variant="success" className="py-2 small">
+                  Transaction submitted!{' '}
+                  <a href={txExplorerUrl} target="_blank" rel="noopener noreferrer">
+                    View on explorer
+                  </a>
+                </Alert>
+              )}
+
+              <Button
+                type="submit"
+                variant="primary"
+                className="w-100"
+                disabled={isSubmitting || !evmWallet.signer}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Spinner as="span" animation="border" size="sm" className="me-2" />
+                    {isWrap ? 'Wrapping...' : 'Unwrapping...'}
+                  </>
+                ) : (
+                  isWrap ? `Wrap ${nativeSymbol} -> ${wrappedSymbol}` : `Unwrap ${wrappedSymbol} -> ${nativeSymbol}`
+                )}
+              </Button>
+            </Form>
+          )}
+        </Card.Body>
+      </Card>
+
+      <Modal show={showConfirm} onHide={() => setShowConfirm(false)} centered>
+        <Modal.Header closeButton>
+          <Modal.Title className="fs-5">
+            Confirm {isWrap ? 'Wrap' : 'Unwrap'}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="mb-2">
+            <strong className="small text-muted">Network</strong>
+            <div>{networkConfig.name} Auto EVM</div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">Action</strong>
+            <div>
+              {isWrap
+                ? `Call deposit() on the WAI3 contract with ${amount} ${nativeSymbol} attached as value`
+                : `Call withdraw(${amount}) on the WAI3 contract`}
+            </div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">Amount</strong>
+            <div className="fs-5 fw-bold">{amount} {sourceSymbol}</div>
+          </div>
+          <div className="mb-2">
+            <strong className="small text-muted">You will receive</strong>
+            <div>{amount} {targetSymbol}</div>
+          </div>
+          <div className="p-2 bg-light rounded small">
+            Your wallet will prompt you to sign the transaction. Gas is paid in native{' '}
+            {nativeSymbol}.
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-secondary" onClick={() => setShowConfirm(false)}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleConfirm}>
+            Confirm in Wallet
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+}

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -205,13 +205,19 @@ export default function WrapPage() {
 
   const handleAddToken = useCallback(async () => {
     setAddTokenStatus(null);
-    const ok = await addWai3ToWallet(selectedNetwork);
-    setAddTokenStatus(
-      ok
-        ? `${wrappedSymbol} was added to your wallet.`
-        : `Could not add ${wrappedSymbol} - your wallet may not support this, or you declined.`,
-    );
-  }, [selectedNetwork, wrappedSymbol]);
+    const result = await addWai3ToWallet(selectedNetwork);
+    if (result.ok) {
+      setAddTokenStatus(`${wrappedSymbol} was added to your wallet.`);
+    } else if (result.reason === 'wrong-chain') {
+      setAddTokenStatus(
+        `Switch your wallet to ${networkConfig.name} Auto EVM (chain ${networkConfig.evmChainId}) before adding ${wrappedSymbol}.`,
+      );
+    } else if (result.reason === 'no-wallet') {
+      setAddTokenStatus('No EVM wallet detected.');
+    } else {
+      setAddTokenStatus(`Could not add ${wrappedSymbol} - your wallet may not support this, or you declined.`);
+    }
+  }, [selectedNetwork, wrappedSymbol, networkConfig.name, networkConfig.evmChainId]);
 
   const explorerBase = networkConfig.explorers.autoEvm;
   const contractExplorerUrl = `${explorerBase}/address/${networkConfig.wai3Address}`;
@@ -271,7 +277,19 @@ export default function WrapPage() {
               variant="outline-primary"
               size="sm"
               onClick={handleAddToken}
-              disabled={!evmWallet.isMetaMaskInstalled || isSubmitting}
+              // Disable when the wallet isn't on the matching chain: otherwise
+              // wallet_watchAsset would register this network's contract
+              // address against whatever chain the wallet is currently on.
+              disabled={
+                !evmWallet.isMetaMaskInstalled
+                || isSubmitting
+                || evmWallet.chainId !== networkConfig.evmChainId
+              }
+              title={
+                evmWallet.chainId !== networkConfig.evmChainId
+                  ? `Switch your wallet to ${networkConfig.name} Auto EVM first`
+                  : undefined
+              }
             >
               Add {wrappedSymbol} token to wallet
             </Button>

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -1,12 +1,22 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Alert, Button, ButtonGroup, Card, Form, Modal, Spinner, ToggleButton } from 'react-bootstrap';
+import { ai3ToShannons, shannonsToAi3 } from '@autonomys/auto-utils';
 import NetworkSelector from '../components/NetworkSelector';
 import EvmWalletConnect from '../components/wallet/EvmWalletConnect';
 import { useEvmWallet } from '../components/wallet/useEvmWallet';
 import { NETWORKS, getEvmChainDisplayName, type NetworkType } from '../config/networks';
-import { getEvmBalance } from '../utils/xdmTransfer';
-import { addWai3ToWallet, getWai3Balance, unwrapWai3, wrapAi3 } from '../utils/wai3';
+import {
+  addWai3ToWallet,
+  formatShannonsAi3,
+  getWai3BalanceShannons,
+  unwrapWai3,
+  wrapAi3,
+} from '../utils/wai3';
 import { describeWalletError } from '../utils/walletErrors';
+
+// Leave this much native AI3 in the wallet to cover gas when the user clicks
+// MAX on a wrap. 0.01 AI3 ≈ enough for several txs at typical Auto EVM fees.
+const GAS_BUFFER_SHANNONS = ai3ToShannons('0.01');
 
 type WrapDirection = 'wrap' | 'unwrap';
 
@@ -24,8 +34,10 @@ export default function WrapPage() {
   const [selectedNetwork, setSelectedNetwork] = useState<NetworkType>('mainnet');
   const [direction, setDirection] = useState<WrapDirection>('wrap');
   const [amount, setAmount] = useState('');
-  const [nativeBalance, setNativeBalance] = useState<string | null>(null);
-  const [wai3Balance, setWai3Balance] = useState<string | null>(null);
+  // Balances tracked in Shannons (BigInt) for exact arithmetic. Formatted
+  // for display with formatShannonsAi3.
+  const [nativeShannons, setNativeShannons] = useState<bigint | null>(null);
+  const [wai3Shannons, setWai3Shannons] = useState<bigint | null>(null);
   const [balanceLoading, setBalanceLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -52,8 +64,8 @@ export default function WrapPage() {
   // Refresh balances when address, network or chain changes
   useEffect(() => {
     if (!evmWallet.address || !evmWallet.provider || isWrongChain) {
-      setNativeBalance(null);
-      setWai3Balance(null);
+      setNativeShannons(null);
+      setWai3Shannons(null);
       return;
     }
     let cancelled = false;
@@ -61,20 +73,20 @@ export default function WrapPage() {
     (async () => {
       try {
         const [native, wai3] = await Promise.all([
-          getEvmBalance(evmWallet.provider!, evmWallet.address!),
-          getWai3Balance(selectedNetwork, evmWallet.provider!, evmWallet.address!),
+          evmWallet.provider!.getBalance(evmWallet.address!),
+          getWai3BalanceShannons(selectedNetwork, evmWallet.provider!, evmWallet.address!),
         ]);
         if (!cancelled) {
-          setNativeBalance(native);
-          setWai3Balance(wai3);
+          setNativeShannons(native);
+          setWai3Shannons(wai3);
         }
       } catch (err) {
         console.error('Failed to fetch balances:', err);
         // Clear stale balances so validation and MAX don't operate on
         // figures that no longer match the current address / network.
         if (!cancelled) {
-          setNativeBalance(null);
-          setWai3Balance(null);
+          setNativeShannons(null);
+          setWai3Shannons(null);
         }
       } finally {
         if (!cancelled) setBalanceLoading(false);
@@ -103,7 +115,7 @@ export default function WrapPage() {
     setShowConfirm(false);
   }, [evmWallet.chainId, evmWallet.address]);
 
-  const sourceBalance = isWrap ? nativeBalance : wai3Balance;
+  const sourceShannons = isWrap ? nativeShannons : wai3Shannons;
   const sourceSymbol = isWrap ? nativeSymbol : wrappedSymbol;
   const targetSymbol = isWrap ? wrappedSymbol : nativeSymbol;
 
@@ -113,25 +125,40 @@ export default function WrapPage() {
     if (isNaN(num) || num <= 0) return 'Amount must be greater than 0.';
     // We must know the source balance before allowing submission; null
     // means it's still loading or the last fetch failed.
-    if (sourceBalance === null) {
+    if (sourceShannons === null) {
       return `${sourceSymbol} balance not loaded yet. Please wait or reconnect.`;
     }
-    if (num > parseFloat(sourceBalance)) {
+    // Compare in Shannons (BigInt) so we don't let through amounts that
+    // round up to within balance but actually exceed it. ai3ToShannons may
+    // throw on out-of-bounds input (e.g. >18 decimals); catch that as a
+    // validation error rather than letting the chain reject it.
+    let amountShannons: bigint;
+    try {
+      amountShannons = ai3ToShannons(amount.trim(), { rounding: 'truncate' });
+    } catch {
+      return 'Amount has too many decimal places. Please use up to 18.';
+    }
+    if (amountShannons <= BigInt(0)) return 'Amount must be greater than 0.';
+    if (amountShannons > sourceShannons) {
       return `Insufficient ${sourceSymbol} balance.`;
     }
     return null;
-  }, [amount, sourceBalance, sourceSymbol]);
+  }, [amount, sourceShannons, sourceSymbol]);
 
   const handleSetMax = useCallback(() => {
-    if (sourceBalance === null) return;
+    if (sourceShannons === null) return;
     if (isWrap) {
-      // leave a small buffer for gas
-      const max = Math.max(0, parseFloat(sourceBalance) - 0.01);
-      setAmount(max > 0 ? max.toFixed(4) : '0');
+      // Wrap consumes native AI3 for gas, so leave a buffer.
+      const max = sourceShannons > GAS_BUFFER_SHANNONS
+        ? sourceShannons - GAS_BUFFER_SHANNONS
+        : BigInt(0);
+      setAmount(max > BigInt(0) ? shannonsToAi3(max) : '0');
     } else {
-      setAmount(sourceBalance);
+      // Unwrap doesn't move native AI3, so the user can unwrap the full
+      // WAI3 balance.
+      setAmount(shannonsToAi3(sourceShannons));
     }
-  }, [sourceBalance, isWrap]);
+  }, [sourceShannons, isWrap]);
 
   const handleSubmit = useCallback((e: React.FormEvent) => {
     e.preventDefault();
@@ -376,13 +403,13 @@ export default function WrapPage() {
                 <div className="d-flex justify-content-between">
                   <span className="text-muted">Native {nativeSymbol} balance:</span>
                   <span className="font-monospace">
-                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (nativeBalance ?? '-')}
+                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (nativeShannons !== null ? formatShannonsAi3(nativeShannons) : '-')}
                   </span>
                 </div>
                 <div className="d-flex justify-content-between">
                   <span className="text-muted">{wrappedSymbol} balance:</span>
                   <span className="font-monospace">
-                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (wai3Balance ?? '-')}
+                    {balanceLoading ? <Spinner size="sm" animation="border" /> : (wai3Shannons !== null ? formatShannonsAi3(wai3Shannons) : '-')}
                   </span>
                 </div>
               </div>
@@ -410,7 +437,7 @@ export default function WrapPage() {
                     variant="outline-secondary"
                     size="sm"
                     onClick={handleSetMax}
-                    disabled={sourceBalance === null || isSubmitting}
+                    disabled={sourceShannons === null || isSubmitting}
                     className="flex-shrink-0"
                   >
                     MAX

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -49,7 +49,7 @@ export default function WrapPage() {
   const evmWallet = useEvmWallet();
   const networkConfig = NETWORKS[selectedNetwork];
   const nativeSymbol = networkConfig.nativeSymbol;
-  const wrappedSymbol = `W${nativeSymbol}`;
+  const wrappedSymbol = networkConfig.wrappedSymbol;
   const isWrap = direction === 'wrap';
   const isWrongChain = evmWallet.isConnected && evmWallet.chainId !== networkConfig.evmChainId;
 

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -77,13 +77,16 @@ export default function WrapPage() {
     return () => { cancelled = true; };
   }, [evmWallet.address, evmWallet.provider, evmWallet.chainId, selectedNetwork, isWrongChain, txHash]);
 
-  // Reset form on direction/network change
+  // Reset form on direction/network change. Closing the confirm modal here
+  // matters: otherwise it can survive a network switch and then submit the
+  // (now stale) amount against the newly-selected network's contract.
   useEffect(() => {
     setAmount('');
     setValidationError(null);
     setSubmitError(null);
     setTxHash(null);
     setAddTokenStatus(null);
+    setShowConfirm(false);
   }, [direction, selectedNetwork]);
 
   const sourceBalance = isWrap ? nativeBalance : wai3Balance;
@@ -136,8 +139,16 @@ export default function WrapPage() {
       const result = isWrap
         ? await wrapAi3({ network: selectedNetwork, signer: evmWallet.signer, amountAi3: amount.trim() })
         : await unwrapWai3({ network: selectedNetwork, signer: evmWallet.signer, amountAi3: amount.trim() });
+      // result.success mirrors receipt.status === 1. A mined-but-reverted tx
+      // has success === false; still surface its hash so the user can inspect
+      // it on the explorer, but flag the failure rather than showing a
+      // green "submitted" confirmation.
       setTxHash(result.txHash);
-      setAmount('');
+      if (result.success) {
+        setAmount('');
+      } else {
+        setSubmitError('Transaction was mined but reverted on-chain. Inspect it on the explorer for details.');
+      }
     } catch (err) {
       console.error('Transaction failed:', err);
       setSubmitError(describeWalletError(err));
@@ -357,9 +368,19 @@ export default function WrapPage() {
                 <Alert variant="warning" className="py-2 small">{validationError}</Alert>
               )}
               {submitError && (
-                <Alert variant="danger" className="py-2 small">{submitError}</Alert>
+                <Alert variant="danger" className="py-2 small">
+                  {submitError}
+                  {txExplorerUrl && (
+                    <>
+                      {' '}
+                      <a href={txExplorerUrl} target="_blank" rel="noopener noreferrer">
+                        View on explorer
+                      </a>
+                    </>
+                  )}
+                </Alert>
               )}
-              {txHash && txExplorerUrl && (
+              {!submitError && txHash && txExplorerUrl && (
                 <Alert variant="success" className="py-2 small">
                   Transaction submitted!{' '}
                   <a href={txExplorerUrl} target="_blank" rel="noopener noreferrer">

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -95,13 +95,13 @@ export default function WrapPage() {
     setShowConfirm(false);
   }, [direction, selectedNetwork]);
 
-  // Close the confirm modal if the wallet's chain changes while it's open,
-  // so a user can't open it on the right chain, switch networks in the
-  // wallet, then submit a wrap/unwrap against the UI network with a signer
-  // on a different chain.
+  // Close the confirm modal if the wallet's chain or account changes while
+  // it's open. Otherwise a user could open the modal on the right chain /
+  // account, switch in the wallet, then submit a wrap/unwrap against the
+  // UI network with a signer on a different chain or account.
   useEffect(() => {
     setShowConfirm(false);
-  }, [evmWallet.chainId]);
+  }, [evmWallet.chainId, evmWallet.address]);
 
   const sourceBalance = isWrap ? nativeBalance : wai3Balance;
   const sourceSymbol = isWrap ? nativeSymbol : wrappedSymbol;
@@ -111,7 +111,12 @@ export default function WrapPage() {
     if (!amount.trim()) return 'Amount is required.';
     const num = parseFloat(amount);
     if (isNaN(num) || num <= 0) return 'Amount must be greater than 0.';
-    if (sourceBalance !== null && num > parseFloat(sourceBalance)) {
+    // We must know the source balance before allowing submission; null
+    // means it's still loading or the last fetch failed.
+    if (sourceBalance === null) {
+      return `${sourceSymbol} balance not loaded yet. Please wait or reconnect.`;
+    }
+    if (num > parseFloat(sourceBalance)) {
       return `Insufficient ${sourceSymbol} balance.`;
     }
     return null;
@@ -141,9 +146,28 @@ export default function WrapPage() {
   }, [validate]);
 
   const handleConfirm = useCallback(async () => {
+    // Guard against double-click races: setIsSubmitting(true) below isn't
+    // visible to a synchronous second click, so check the flag directly.
+    if (isSubmitting) return;
     setShowConfirm(false);
     if (!evmWallet.signer) {
       setSubmitError('EVM wallet not connected.');
+      return;
+    }
+    // Re-validate at submit time so a closure captured before the user
+    // changed network / amount / balance can't ship a stale request.
+    const validationErr = validate();
+    if (validationErr) {
+      setSubmitError(validationErr);
+      return;
+    }
+    // Verify the wallet is still on the network we're about to transact
+    // against - chain switches in the wallet are async and the modal-close
+    // effect may race with this submit.
+    if (evmWallet.chainId !== networkConfig.evmChainId) {
+      setSubmitError(
+        `Wallet is on chain ${evmWallet.chainId ?? '?'} but the UI is targeting ${networkConfig.name} (chain ${networkConfig.evmChainId}). Switch your wallet and try again.`,
+      );
       return;
     }
     setIsSubmitting(true);
@@ -169,7 +193,7 @@ export default function WrapPage() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [evmWallet.signer, isWrap, selectedNetwork, amount]);
+  }, [isSubmitting, evmWallet.signer, evmWallet.chainId, networkConfig.evmChainId, networkConfig.name, isWrap, selectedNetwork, amount, validate]);
 
   const handleAddNetwork = useCallback(async () => {
     await evmWallet.switchChain(
@@ -225,7 +249,7 @@ export default function WrapPage() {
         </Card.Body>
       </Card>
 
-      <NetworkSelector selectedNetwork={selectedNetwork} onChange={setSelectedNetwork} />
+      <NetworkSelector selectedNetwork={selectedNetwork} onChange={setSelectedNetwork} disabled={isSubmitting} />
 
       <Card className="mb-4">
         <Card.Body>
@@ -239,7 +263,7 @@ export default function WrapPage() {
               variant="outline-primary"
               size="sm"
               onClick={handleAddNetwork}
-              disabled={!evmWallet.isMetaMaskInstalled}
+              disabled={!evmWallet.isMetaMaskInstalled || isSubmitting}
             >
               Add {networkConfig.name} Auto EVM (chain {networkConfig.evmChainId})
             </Button>
@@ -247,7 +271,7 @@ export default function WrapPage() {
               variant="outline-primary"
               size="sm"
               onClick={handleAddToken}
-              disabled={!evmWallet.isMetaMaskInstalled}
+              disabled={!evmWallet.isMetaMaskInstalled || isSubmitting}
             >
               Add {wrappedSymbol} token to wallet
             </Button>
@@ -294,6 +318,7 @@ export default function WrapPage() {
               name="wrapDirToggle"
               value={d}
               checked={direction === d}
+              disabled={isSubmitting}
               onChange={() => setDirection(d)}
             >
               {directionLabel(d, nativeSymbol, wrappedSymbol)}
@@ -459,8 +484,8 @@ export default function WrapPage() {
           <Button variant="outline-secondary" onClick={() => setShowConfirm(false)}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handleConfirm}>
-            Confirm in Wallet
+          <Button variant="primary" onClick={handleConfirm} disabled={isSubmitting}>
+            {isSubmitting ? 'Submitting…' : 'Confirm in Wallet'}
           </Button>
         </Modal.Footer>
       </Modal>

--- a/pages/xdm/send.tsx
+++ b/pages/xdm/send.tsx
@@ -7,7 +7,8 @@ import EvmWalletConnect from '../../components/wallet/EvmWalletConnect';
 import SendForm from '../../components/SendForm';
 import { useSubstrateWallet } from '../../components/wallet/useSubstrateWallet';
 import { useEvmWallet } from '../../components/wallet/useEvmWallet';
-import { NETWORKS, type NetworkType } from '../../config/networks';
+import { NETWORKS, getEvmChainDisplayName, type NetworkType } from '../../config/networks';
+import { describeWalletError } from '../../utils/walletErrors';
 import {
   transferConsensusToEvm,
   transferEvmToConsensus,
@@ -40,7 +41,7 @@ export default function SendPage() {
   const handleSwitchEvmChain = useCallback(async () => {
     await evmWallet.switchChain(
       networkConfig.evmChainId,
-      `Autonomys ${networkConfig.name} Auto EVM`,
+      getEvmChainDisplayName(selectedNetwork),
       networkConfig.evmRpcHttp,
     );
   }, [evmWallet, networkConfig]);
@@ -77,13 +78,7 @@ export default function SendPage() {
       router.push(`/xdm/transfers?search=${encodeURIComponent(searchAddr)}&network=${selectedNetwork}`);
     } catch (err) {
       console.error('Transfer failed:', err);
-      const raw = err instanceof Error ? err.message : String(err);
-      // Detect user rejection from wallet
-      const isRejected = /user rejected|cancelled|action_rejected|rejected by user/i.test(raw);
-      const message = isRejected
-        ? 'Transaction was rejected in your wallet.'
-        : raw || 'Transfer failed. Please try again.';
-      setSubmitError(message);
+      setSubmitError(describeWalletError(err, 'Transfer failed. Please try again.'));
     } finally {
       setIsSubmitting(false);
     }
@@ -150,7 +145,7 @@ export default function SendPage() {
             address={evmWallet.address}
             chainId={evmWallet.chainId}
             expectedChainId={networkConfig.evmChainId}
-            expectedChainName={`Autonomys ${networkConfig.name} Auto EVM`}
+            expectedChainName={getEvmChainDisplayName(selectedNetwork)}
             error={evmWallet.error}
             isMetaMaskInstalled={evmWallet.isMetaMaskInstalled}
             onConnect={evmWallet.connect}

--- a/utils/evmFees.ts
+++ b/utils/evmFees.ts
@@ -1,0 +1,21 @@
+import type { JsonRpcSigner } from 'ethers';
+
+/**
+ * Fetch current EIP-1559 fee data from the connected provider so a tx meets
+ * the block base fee.
+ *
+ * MetaMask's built-in fee estimator is tuned for Ethereum mainnet/L2s and
+ * frequently picks a maxFeePerGas below Auto EVM's current base fee, which the
+ * node then rejects with "gas price less than block base fee". Passing the
+ * RPC's own values explicitly bypasses MetaMask's estimator.
+ */
+export async function getEvmFeeOverrides(signer: JsonRpcSigner): Promise<{
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+}> {
+  const feeData = await signer.provider.getFeeData();
+  return {
+    maxFeePerGas: feeData.maxFeePerGas ?? undefined,
+    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas ?? undefined,
+  };
+}

--- a/utils/wai3.ts
+++ b/utils/wai3.ts
@@ -1,5 +1,5 @@
-import { ai3ToShannons } from '@autonomys/auto-utils';
-import { Contract, formatUnits } from 'ethers';
+import { ai3ToShannons, shannonsToAi3 } from '@autonomys/auto-utils';
+import { Contract } from 'ethers';
 import type { JsonRpcSigner, BrowserProvider } from 'ethers';
 import { NETWORKS, type NetworkType } from '../config/networks';
 import { getEvmFeeOverrides } from './evmFees';
@@ -72,18 +72,37 @@ export async function unwrapWai3(params: {
 }
 
 /**
- * Read the WAI3 balance of an address, formatted as a 4-decimal AI3 string.
+ * Read the WAI3 balance of an address in Shannons (the smallest unit, 1e-18 AI3).
+ *
+ * Returns the raw bigint so callers can do exact comparisons against
+ * `ai3ToShannons(amount)` and avoid the JS-number rounding that bit us
+ * before (Number(formatUnits(...)).toFixed(4) can round *up*, which made
+ * MAX / insufficient-balance checks let through amounts slightly larger
+ * than the wallet actually holds).
+ *
+ * Use `shannonsToAi3` from @autonomys/auto-utils to format for display.
  */
-export async function getWai3Balance(
+export async function getWai3BalanceShannons(
   network: NetworkType,
   provider: BrowserProvider,
   address: string,
-): Promise<string> {
+): Promise<bigint> {
   const { wai3Address } = NETWORKS[network];
   const contract = new Contract(wai3Address, WAI3_ABI, provider);
-  const raw: bigint = await contract.balanceOf(address);
-  // WAI3 uses 18 decimals (same as native AI3)
-  return Number(formatUnits(raw, 18)).toFixed(4);
+  return await contract.balanceOf(address);
+}
+
+/**
+ * Format a Shannon amount as an AI3 display string truncated to a fixed
+ * number of decimal places. Truncation never inflates the displayed value
+ * above what's actually there, which matters for balances feeding into
+ * MAX and validation.
+ */
+export function formatShannonsAi3(shannons: bigint, decimals = 4): string {
+  const precise = shannonsToAi3(shannons);
+  const [intPart, fracPart = ''] = precise.split('.');
+  if (decimals === 0) return intPart;
+  return `${intPart}.${fracPart.slice(0, decimals).padEnd(decimals, '0')}`;
 }
 
 export type AddWai3Result =

--- a/utils/wai3.ts
+++ b/utils/wai3.ts
@@ -86,14 +86,28 @@ export async function getWai3Balance(
   return Number(formatUnits(raw, 18)).toFixed(4);
 }
 
+export type AddWai3Result =
+  | { ok: true }
+  | { ok: false; reason: 'no-wallet' | 'wrong-chain' | 'declined' };
+
 /**
  * Ask the connected wallet (MetaMask) to track WAI3 as an ERC-20.
- * Returns true if the user added the token, false if they declined or it failed.
+ *
+ * wallet_watchAsset registers the address against the wallet's *current*
+ * chain — there's no way to specify which chain the token belongs to. So
+ * we verify the wallet is on the expected Auto EVM chain before issuing
+ * the request; otherwise the user ends up with e.g. the mainnet WAI3
+ * address showing up as a token on Chronos.
  */
-export async function addWai3ToWallet(network: NetworkType): Promise<boolean> {
-  if (typeof window === 'undefined' || !window.ethereum) return false;
-  const { wai3Address, nativeSymbol } = NETWORKS[network];
+export async function addWai3ToWallet(network: NetworkType): Promise<AddWai3Result> {
+  if (typeof window === 'undefined' || !window.ethereum) return { ok: false, reason: 'no-wallet' };
+  const { wai3Address, nativeSymbol, evmChainId } = NETWORKS[network];
   try {
+    const walletChainHex = await window.ethereum.request({ method: 'eth_chainId' }) as string;
+    const walletChainId = parseInt(walletChainHex, 16);
+    if (walletChainId !== evmChainId) {
+      return { ok: false, reason: 'wrong-chain' };
+    }
     const result = await window.ethereum.request({
       method: 'wallet_watchAsset',
       // wallet_watchAsset expects an object, not an array — MetaMask accepts both
@@ -107,8 +121,8 @@ export async function addWai3ToWallet(network: NetworkType): Promise<boolean> {
         },
       } as unknown as unknown[],
     });
-    return Boolean(result);
+    return result ? { ok: true } : { ok: false, reason: 'declined' };
   } catch {
-    return false;
+    return { ok: false, reason: 'declined' };
   }
 }

--- a/utils/wai3.ts
+++ b/utils/wai3.ts
@@ -1,0 +1,114 @@
+import { ai3ToShannons } from '@autonomys/auto-utils';
+import { Contract, formatUnits } from 'ethers';
+import type { JsonRpcSigner, BrowserProvider } from 'ethers';
+import { NETWORKS, type NetworkType } from '../config/networks';
+import { getEvmFeeOverrides } from './evmFees';
+
+/**
+ * Minimal ABI for the WAI3 contract.
+ * WAI3 is a WETH-style wrapper: `deposit()` wraps native AI3 sent with the tx,
+ * `withdraw(uint256)` unwraps WAI3 back to native AI3, and standard ERC-20
+ * methods expose balance and metadata.
+ */
+export const WAI3_ABI = [
+  'function deposit() payable',
+  'function withdraw(uint256 amount)',
+  'function balanceOf(address owner) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+  'function symbol() view returns (string)',
+] as const;
+
+export interface WrapResult {
+  success: boolean;
+  txHash: string;
+  blockNumber?: number;
+}
+
+/**
+ * Wrap native AI3 into WAI3 by calling `deposit()` with the native amount as value.
+ */
+export async function wrapAi3(params: {
+  network: NetworkType;
+  signer: JsonRpcSigner;
+  amountAi3: string;
+}): Promise<WrapResult> {
+  const { network, signer, amountAi3 } = params;
+  const { wai3Address } = NETWORKS[network];
+  const value = ai3ToShannons(amountAi3);
+
+  const contract = new Contract(wai3Address, WAI3_ABI, signer);
+  const tx = await contract.deposit({
+    value,
+    ...(await getEvmFeeOverrides(signer)),
+  });
+  const receipt = await tx.wait();
+  return {
+    success: receipt?.status === 1,
+    txHash: tx.hash,
+    blockNumber: receipt?.blockNumber,
+  };
+}
+
+/**
+ * Unwrap WAI3 back into native AI3 by calling `withdraw(amount)`.
+ */
+export async function unwrapWai3(params: {
+  network: NetworkType;
+  signer: JsonRpcSigner;
+  amountAi3: string;
+}): Promise<WrapResult> {
+  const { network, signer, amountAi3 } = params;
+  const { wai3Address } = NETWORKS[network];
+  const amount = ai3ToShannons(amountAi3);
+
+  const contract = new Contract(wai3Address, WAI3_ABI, signer);
+  const tx = await contract.withdraw(amount, await getEvmFeeOverrides(signer));
+  const receipt = await tx.wait();
+  return {
+    success: receipt?.status === 1,
+    txHash: tx.hash,
+    blockNumber: receipt?.blockNumber,
+  };
+}
+
+/**
+ * Read the WAI3 balance of an address, formatted as a 4-decimal AI3 string.
+ */
+export async function getWai3Balance(
+  network: NetworkType,
+  provider: BrowserProvider,
+  address: string,
+): Promise<string> {
+  const { wai3Address } = NETWORKS[network];
+  const contract = new Contract(wai3Address, WAI3_ABI, provider);
+  const raw: bigint = await contract.balanceOf(address);
+  // WAI3 uses 18 decimals (same as native AI3)
+  return Number(formatUnits(raw, 18)).toFixed(4);
+}
+
+/**
+ * Ask the connected wallet (MetaMask) to track WAI3 as an ERC-20.
+ * Returns true if the user added the token, false if they declined or it failed.
+ */
+export async function addWai3ToWallet(network: NetworkType): Promise<boolean> {
+  if (typeof window === 'undefined' || !window.ethereum) return false;
+  const { wai3Address, nativeSymbol } = NETWORKS[network];
+  try {
+    const result = await window.ethereum.request({
+      method: 'wallet_watchAsset',
+      // wallet_watchAsset expects an object, not an array — MetaMask accepts both
+      // but the EIP-747 shape is a plain object. Cast to the loose params type.
+      params: {
+        type: 'ERC20',
+        options: {
+          address: wai3Address,
+          symbol: `W${nativeSymbol}`,
+          decimals: 18,
+        },
+      } as unknown as unknown[],
+    });
+    return Boolean(result);
+  } catch {
+    return false;
+  }
+}

--- a/utils/wai3.ts
+++ b/utils/wai3.ts
@@ -120,7 +120,7 @@ export type AddWai3Result =
  */
 export async function addWai3ToWallet(network: NetworkType): Promise<AddWai3Result> {
   if (typeof window === 'undefined' || !window.ethereum) return { ok: false, reason: 'no-wallet' };
-  const { wai3Address, nativeSymbol, evmChainId } = NETWORKS[network];
+  const { wai3Address, wrappedSymbol, evmChainId } = NETWORKS[network];
   try {
     const walletChainHex = await window.ethereum.request({ method: 'eth_chainId' }) as string;
     const walletChainId = parseInt(walletChainHex, 16);
@@ -135,7 +135,7 @@ export async function addWai3ToWallet(network: NetworkType): Promise<AddWai3Resu
         type: 'ERC20',
         options: {
           address: wai3Address,
-          symbol: `W${nativeSymbol}`,
+          symbol: wrappedSymbol,
           decimals: 18,
         },
       } as unknown as unknown[],

--- a/utils/walletErrors.ts
+++ b/utils/walletErrors.ts
@@ -1,0 +1,19 @@
+/**
+ * Detect whether a thrown error represents the user rejecting a wallet prompt.
+ * Covers MetaMask ("user rejected"/"User rejected the request"), ethers
+ * (ACTION_REJECTED), and a few Substrate/Polkadot phrasings.
+ */
+export function isUserRejection(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /user rejected|cancelled|action_rejected|rejected by user/i.test(msg);
+}
+
+/**
+ * Turn an error from a wallet-signed transaction into a message suitable for
+ * the UI: a friendly string for user-rejection, otherwise the raw error.
+ */
+export function describeWalletError(err: unknown, fallback = 'Transaction failed. Please try again.'): string {
+  if (isUserRejection(err)) return 'Transaction was rejected in your wallet.';
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw || fallback;
+}

--- a/utils/xdmTransfer.ts
+++ b/utils/xdmTransfer.ts
@@ -6,6 +6,7 @@ import { isAddress as isValidEthersAddress } from 'ethers';
 import type { JsonRpcSigner, BrowserProvider } from 'ethers';
 import type { NetworkType } from '../config/networks';
 import { NETWORKS } from '../config/networks';
+import { getEvmFeeOverrides } from './evmFees';
 
 export type TransferDirection = 'consensus-to-evm' | 'evm-to-consensus';
 
@@ -62,14 +63,12 @@ export async function transferEvmToConsensus(params: {
   const { signer, recipientSs58Address, amountAi3 } = params;
   const amount = ai3ToShannons(amountAi3);
 
-  // Fetch current fee data so the tx meets the block base fee
-  const provider = signer.provider;
-  const feeData = await provider.getFeeData();
-
-  const result = await transferToConsensus(signer, recipientSs58Address, amount, {
-    maxFeePerGas: feeData.maxFeePerGas ?? undefined,
-    maxPriorityFeePerGas: feeData.maxPriorityFeePerGas ?? undefined,
-  });
+  const result = await transferToConsensus(
+    signer,
+    recipientSs58Address,
+    amount,
+    await getEvmFeeOverrides(signer),
+  );
   return {
     success: result.success,
     txHash: result.transactionHash,


### PR DESCRIPTION
## Summary
Adds a new `/wrap` page that lets users connect an EVM wallet on mainnet or Chronos and wrap native AI3/tAI3 into WAI3 (a WETH-style ERC-20 wrapper) or unwrap it back. The page is stepwise and explanatory, with buttons to add the Auto EVM network and the WAI3 token to the connected wallet, balance display for both native and wrapped tokens, and a confirmation modal that names the actual contract call. Links to the upstream docs at https://develop.autonomys.xyz/evm/wrapping_ai3.

Along the way:
- Introduces small shared helpers used by both `/wrap` and the existing XDM pages: `utils/evmFees.ts` (EIP-1559 fee overrides), `utils/walletErrors.ts` (user-rejection detection / message shaping), and a `getEvmChainDisplayName` helper in the network config.
- Refactors the XDM send page and transfer utility to consume those helpers, removing per-page duplication of the wallet-rejection regex, the fee-override block, and the chain display name.
- Fixes an SSR/CSR hydration mismatch in `useEvmWallet` (the synchronous `window.ethereum` check produced different button `disabled` attributes between server and first client render).
- Mirrors the wheel-scroll fix from PR #15 onto the WAI3 page's number input (it doesn't share `SendForm`).

## Submit-time safety hardening
A series of Bugbot-flagged issues all in the family of "UI state captured at modal-open time can be stale by the time the user clicks Confirm" got fixed iteratively:
- Reverted transactions are surfaced as errors (not green "submitted" alerts), with the tx hash linked for explorer inspection.
- The confirm modal closes on direction, selected-network, wallet chain-id, or wallet account change, so it can't persist across a state shift.
- `handleConfirm` re-validates at submit time, re-checks the wallet's chain matches the UI's target, and guards against double-clicks via `isSubmitting`.
- Submit is blocked when balances haven't loaded (rather than silently skipping the insufficient-balance check).
- Network selector and direction toggle are disabled while a tx is in flight.
- "Add token to wallet" is gated on the wallet actually being on the matching chain; `addWai3ToWallet` re-checks `eth_chainId` before calling `wallet_watchAsset` (which has no chain parameter and would otherwise register the address against the wallet's current chain regardless of the UI).
- Balance math now uses BigInt Shannons end-to-end via `ai3ToShannons` / `shannonsToAi3` from `@autonomys/auto-utils`. The previous `Number(formatUnits(raw, 18)).toFixed(4)` round-trip rounded *up*, so MAX and insufficient-balance checks could let through amounts that exceeded the wallet's actual holding and revert on-chain.

## Commits
1. `feat: implement WAI3 wrapping interface` - new page, utilities, network config additions, home reorg into XDM/WAI3 sections.
2. `refactor: route XDM transfer through shared EVM helpers` - XDM send/transfer switched to the new helpers.
3. `fix: defer MetaMask detection past mount to avoid SSR hydration mismatch`.
4. `fix: don't change WAI3 amount when scrolling the wheel over the input`.
5. `fix: handle reverted transactions and stale confirm modal on wrap page`.
6. `fix: close confirm modal on chain switch; clear balances on fetch error`.
7. `fix: re-validate wrap submission against current state at confirm time`.
8. `fix: don't register WAI3 against the wrong chain in the user's wallet`.
9. `fix: use BigInt Shannons via SDK helpers to avoid balance-rounding bug`.

## Test plan
- [x] `npm run dev`, open `/` - verify XDM and WAI3 sections, click the WAI3 link.
- [x] On `/wrap` with no wallet installed: page renders without hydration error, the "no wallet detected" copy shows.
- [x] With MetaMask installed: "Add Auto EVM network" works for both Mainnet and Chronos. "Add WAI3 token to wallet" is disabled while the wallet is on the wrong chain; enables and works once on the matching chain.
- [x] Wrap a small amount of tAI3 on Chronos - confirm WAI3 balance goes up, tAI3 balance goes down by amount + gas.
- [x] Unwrap that WAI3 - confirm tAI3 returns and WAI3 balance goes down. The MAX button should produce an exact-balance amount that the chain accepts (no "insufficient balance" revert).
- [ ] Switch network selector or direction while the confirm modal is open - modal closes.
- [ ] Switch the wallet's chain while the confirm modal is open - modal closes.
- [ ] Open the confirm modal, switch wallet to the wrong chain, then re-open and try to confirm - submit is rejected with a clear error rather than firing a tx against the wrong chain.
- [ ] Force a reverted transaction (e.g. unwrap more than balance via DevTools) - UI shows a red "reverted on-chain" alert with the explorer link, not a green success.
- [x] Wheel-scroll over the amount input does not change the amount.
- [x] XDM send page (`/xdm/send`) still works end-to-end on Chronos (regression check after the helper refactor).