### PR TITLE
Serve site at subspace.tools custom domain

### DIFF
--- a/components/TransferList.tsx
+++ b/components/TransferList.tsx
@@ -20,8 +20,7 @@ const TransferList: React.FC<TransferListProps> = ({ transfers, searchAddress, p
     if (network !== 'mainnet') {
       params.set('network', network);
     }
-    const basePath = process.env.NODE_ENV === 'production' ? '/autonomys-helpers' : '';
-    const url = `${window.location.origin}${basePath}/xdm/transfers/?${params.toString()}`;
+    const url = `${window.location.origin}/xdm/transfers/?${params.toString()}`;
 
     try {
       await navigator.clipboard.writeText(url);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,9 @@
 /** @type {import('next').NextConfig} */
-const isProd = process.env.NODE_ENV === 'production';
-
 const nextConfig = {
   output: 'export',
   images: {
     unoptimized: true,
   },
-  basePath: isProd ? '/autonomys-helpers' : '',
-  assetPrefix: isProd ? '/autonomys-helpers/' : '',
   trailingSlash: true,
 };
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+subspace.tools


### PR DESCRIPTION
## Summary

First step of the Subspace Tools rebrand: move the site from `autonomys-community.github.io/autonomys-helpers` to https://subspace.tools.

- Remove the `/autonomys-helpers` `basePath`/`assetPrefix` from `next.config.ts` — on the custom domain the site serves from the root
- Remove the matching hardcoded basePath from the share-link builder in `TransferList.tsx`
- Add `public/CNAME` containing `subspace.tools` so the `gh-pages` deploy (which replaces the branch wholesale) re-publishes the custom-domain claim on every deploy instead of wiping it

## DNS state (already live)

- Nameservers moved from Netlify DNS back to GoDaddy
- Apex A records → GitHub Pages IPs (185.199.108–111.153), `www` CNAME in place
- `subspace.tools` verified on the autonomys-community org

## On merge

The deploy workflow publishes the root-path build with the CNAME file, GitHub registers the custom domain, and Let's Encrypt cert issuance begins (minutes to ~1 hour before HTTPS works). Old `github.io/autonomys-helpers/...` links will redirect to subspace.tools with paths preserved.

Build verified locally: static export clean, all asset/link paths root-relative, `out/CNAME` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy and URL routing change affects all asset paths and shared links; old github.io paths rely on GitHub redirect behavior after merge.
> 
> **Overview**
> Moves the static export from GitHub Pages under `/autonomys-helpers` to the **subspace.tools** custom domain at the site root.
> 
> **Next.js config** drops production-only `basePath` and `assetPrefix`, so routes and assets are root-relative on deploy. **Transfer share links** no longer prepend `/autonomys-helpers`; copied URLs use `/xdm/transfers/` on the current origin. **`public/CNAME`** adds `subspace.tools` so gh-pages deploys keep the custom-domain claim instead of wiping it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6941aa757936781fd469c892ba2dad653ad1778e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->