### PR TITLE
Rebrand Autonomys Helpers to Subspace Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Autonomys Helpers
+# Subspace Tools
 
 A collection of tools for working with the Autonomys Network and ecosystem.
 
@@ -59,7 +59,7 @@ This will:
 
 You can access the deployed site at:
 
-📦 https://autonomys-community.github.io/autonomys-helpers/
+📦 https://subspace.tools/
 
 ---
 

--- a/components/wallet/useSubstrateWallet.ts
+++ b/components/wallet/useSubstrateWallet.ts
@@ -9,7 +9,7 @@ let storeInstance: ReturnType<typeof createWalletStore> | null = null;
 function getStore() {
   if (!storeInstance) {
     storeInstance = createWalletStore({
-      dappName: 'Autonomys Helpers',
+      dappName: 'Subspace Tools',
       ss58Prefix: 6094,
       storageKey: 'autonomys-helpers-substrate-wallet',
     });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "autonomys-helpers",
+  "name": "subspace-tools",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://autonomys-community.github.io/autonomys-helpers",
+  "homepage": "https://subspace.tools",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,19 @@
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { AppProps } from 'next/app'
+import Head from 'next/head'
 import Link from 'next/link'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
+      <Head>
+        <title>Subspace Tools</title>
+        <meta name="description" content="A collection of tools for working with the Autonomys Network and ecosystem." />
+      </Head>
       <nav className="navbar navbar-light bg-white border-bottom">
         <div className="container d-flex justify-content-between align-items-center">
           <Link href="/" className="navbar-brand fw-bold">
-            Autonomys Helpers
+            Subspace Tools
           </Link>
           <a
             href="https://github.com/autonomys-community/autonomys-helpers"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <div className="container py-5">
-      <h1>Autonomys Helpers</h1>
+      <h1>Subspace Tools</h1>
 
       <h2 className="fs-4 mt-4">XDM</h2>
       <ul>


### PR DESCRIPTION
## Summary

Now that the site serves from https://subspace.tools (#20), update the user-facing branding to match.

- **Navbar brand** + **home heading**: `Autonomys Helpers` → `Subspace Tools`
- **Page `<title>` + meta description**: added a `<Head>` — the site previously had no `<title>` at all, so browser tabs showed nothing
- **Wallet `dappName`**: `Subspace Tools` (this is the name wallet extensions show in their connection-approval prompt)
- **`package.json`**: name → `subspace-tools`, homepage → `https://subspace.tools`
- **README**: title + deployed-site URL

## Deliberately left unchanged

- **GitHub repo URL** in the navbar "Contribute" link — correct until the repo itself is renamed (GitHub redirects the old URL afterward). Update it in the eventual repo-rename PR.
- **Wallet `storageKey`** (`autonomys-helpers-substrate-wallet`) — renaming it would log every returning user out of their saved wallet selection for a one-time reconnect, with no user-visible benefit. It's an internal key.

The description text still references "the Autonomys Network and ecosystem" since the network itself isn't being renamed — only this tools site.

Build verified locally: static export compiles, `<title>Subspace Tools</title>` renders in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic and metadata-only changes with no auth, data, or business-logic modifications.
> 
> **Overview**
> Realigns user-facing branding with the **https://subspace.tools** deployment: navbar and home **h1** now say **Subspace Tools**, and **`package.json`** / README use the new name and homepage URL.
> 
> Adds global document metadata via **`next/head`** in `_app.tsx` (**`<title>Subspace Tools</title>`** and a meta description) so browser tabs and SEO reflect the site name.
> 
> Updates the Substrate wallet **`dappName`** to **Subspace Tools** so extension connection prompts match the site; the wallet **`storageKey`** is unchanged to avoid clearing saved wallet state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13dce9808de48f11ebacf0fbb914599628f84985. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->