### PR TITLE
Update repo links and wallet storage key after rename

### DIFF
--- a/components/wallet/useSubstrateWallet.ts
+++ b/components/wallet/useSubstrateWallet.ts
@@ -11,7 +11,7 @@ function getStore() {
     storeInstance = createWalletStore({
       dappName: 'Subspace Tools',
       ss58Prefix: 6094,
-      storageKey: 'autonomys-helpers-substrate-wallet',
+      storageKey: 'subspace-tools-substrate-wallet',
     });
   }
   return storeInstance;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,7 +16,7 @@ export default function App({ Component, pageProps }: AppProps) {
             Subspace Tools
           </Link>
           <a
-            href="https://github.com/autonomys-community/autonomys-helpers"
+            href="https://github.com/autonomys-community/subspace-tools"
             target="_blank"
             rel="noopener noreferrer"
             className="d-flex align-items-center gap-1 text-muted text-decoration-none small"


### PR DESCRIPTION
Tidy-up following the repo rename to `subspace-tools` and the rebrand (#20, #21).

- **Contribute link** in the navbar → `https://github.com/autonomys-community/subspace-tools` (the old URL still redirects, but point it at the canonical name)
- **Wallet `storageKey`** → `subspace-tools-substrate-wallet`, completing the rebrand of the last `autonomys-helpers` string in the source

### Note on the storage-key change
Returning users will see a one-time "connect wallet" prompt — the old key's saved value is orphaned in localStorage, not migrated. This is the deliberate trade-off discussed in the #21 comments; a migration shim wasn't considered worth it for a single reconnect.

Build verified locally; no `autonomys-helpers` references remain in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only branding updates; the storage key change only affects wallet persistence UX (one-time reconnect), not security or core logic.
> 
> **Overview**
> Finishes the **subspace-tools** rename by updating the last **`autonomys-helpers`** strings in app source.
> 
> The navbar **Contribute** link now targets **`https://github.com/autonomys-community/subspace-tools`**. The substrate wallet store **`storageKey`** is **`subspace-tools-substrate-wallet`** instead of **`autonomys-helpers-substrate-wallet`**.
> 
> **Wallet reconnect:** persisted wallet state under the old key is not migrated, so returning users may need to connect their wallet once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57405324886b84fceb5dcc5455ecf5e606d5aeb9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->