### PR TITLE
Footer GitHub icon and header/copy cleanup

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,9 +4,17 @@ export default function Footer() {
   return (
     <footer className="site-footer mt-5">
       <div className="container d-flex flex-column flex-sm-row justify-content-between align-items-center gap-2 py-4">
-        <span>Subspace Tools — community tools for the Autonomys Network.</span>
+        <span>Subspace Tools, community tools for the Autonomys Network.</span>
         <nav className="d-flex gap-3">
-          <a href="https://github.com/autonomys-community/subspace-tools" target="_blank" rel="noopener noreferrer">
+          <a
+            href="https://github.com/autonomys-community/subspace-tools"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="d-inline-flex align-items-center gap-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
             GitHub
           </a>
           <a href="https://autonomys.xyz" target="_blank" rel="noopener noreferrer">

--- a/components/wallet/EvmWalletConnect.tsx
+++ b/components/wallet/EvmWalletConnect.tsx
@@ -114,7 +114,7 @@ const EvmWalletConnect: React.FC<EvmWalletConnectProps> = ({
         </div>
       ) : noWallets ? (
         <div className="small text-muted">
-          No EVM wallet detected. Install one to continue —{' '}
+          No EVM wallet detected. Install one to continue:{' '}
           <a href="https://metamask.io/download/" target="_blank" rel="noopener noreferrer">MetaMask</a>,{' '}
           <a href="https://rabby.io/" target="_blank" rel="noopener noreferrer">Rabby</a>,{' '}
           or any browser wallet that supports EIP-6963.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -27,18 +27,6 @@ export default function App({ Component, pageProps }: AppProps) {
             </Link>
             <SiteNav />
           </div>
-          <a
-            href="https://github.com/autonomys-community/subspace-tools"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="d-flex align-items-center gap-1 text-muted text-decoration-none small"
-            title="View source on GitHub"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-            </svg>
-            Contribute
-          </a>
         </div>
       </nav>
       <main className="flex-grow-1">


### PR DESCRIPTION
Follow-up tweaks after the UI refresh (#23).

- **Footer**: add the GitHub mark next to the GitHub link.
- **Header**: remove the Contribute link. Source is still reachable via the footer GitHub link, so nothing is lost.
- **Copy**: remove em dashes from user-facing text, per house style (no long dashes in copy the user sees) — comma in the footer brand line, colon in the EVM "no wallet detected" message. Remaining em dashes in the codebase are all in code comments.

Build verified locally; changes verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and copy changes with no auth, wallet logic, or data handling updates.
> 
> **Overview**
> Polishes post–UI refresh navigation and copy. The **navbar** no longer shows the **Contribute** GitHub link; repo access moves to the **footer** GitHub entry, which now includes an inline **GitHub mark** and flex alignment for icon + label.
> 
> User-facing punctuation follows house style: the footer tagline uses a **comma** instead of an em dash, and the EVM “no wallet detected” hint uses a **colon** instead of an em dash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c82b37296ae6f81f05994f0fc0e662493863c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->