### PR TITLE
Replace toggle button groups with a segmented control

### DIFF
--- a/components/NetworkSelector.tsx
+++ b/components/NetworkSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonGroup, ToggleButton } from 'react-bootstrap';
+import SegmentedControl from './SegmentedControl';
 import { NETWORKS, NetworkType } from '../config/networks';
 
 interface NetworkSelectorProps {
@@ -12,23 +12,17 @@ const NetworkSelector: React.FC<NetworkSelectorProps> = ({ selectedNetwork, onCh
   return (
     <div className="mb-4">
       <label className="form-label fw-bold">Select Network:</label>
-      <ButtonGroup className="w-100">
-        {(Object.keys(NETWORKS) as NetworkType[]).map((key) => (
-          <ToggleButton
-            key={key}
-            id={`toggle-${key}`}
-            type="radio"
-            variant={selectedNetwork === key ? 'primary' : 'outline-primary'}
-            name="networkToggle"
-            value={key}
-            checked={selectedNetwork === key}
-            disabled={disabled}
-            onChange={() => onChange(key)}
-          >
-            {NETWORKS[key].name}
-          </ToggleButton>
-        ))}
-      </ButtonGroup>
+      <SegmentedControl
+        name="networkToggle"
+        ariaLabel="Select network"
+        value={selectedNetwork}
+        disabled={disabled}
+        onChange={onChange}
+        options={(Object.keys(NETWORKS) as NetworkType[]).map((key) => ({
+          value: key,
+          label: NETWORKS[key].name,
+        }))}
+      />
     </div>
   );
 };

--- a/components/SegmentedControl.tsx
+++ b/components/SegmentedControl.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedControlProps<T extends string> {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  name: string;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+// A modern segmented control: a pill track where the active option reads as a
+// raised "thumb". Backed by real radio inputs so keyboard/AT behaviour matches
+// a native radio group. Drop-in replacement for the ButtonGroup/ToggleButton
+// pattern used across the tool pages.
+export default function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  name,
+  disabled = false,
+  ariaLabel,
+}: SegmentedControlProps<T>) {
+  return (
+    <div className="segmented" role="radiogroup" aria-label={ariaLabel}>
+      {options.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <label
+            key={opt.value}
+            className={`segmented__option${active ? ' segmented__option--active' : ''}`}
+          >
+            <input
+              type="radio"
+              className="visually-hidden"
+              name={name}
+              value={opt.value}
+              checked={active}
+              disabled={disabled}
+              onChange={() => onChange(opt.value)}
+            />
+            <span>{opt.label}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig = {
   sassOptions: {
     // Bootstrap 5.3 still uses @import internally; silence the Dart Sass
     // deprecation noise until Bootstrap migrates to @use.
-    silenceDeprecations: ['import', 'global-builtin', 'color-functions'],
+    silenceDeprecations: ['import', 'global-builtin', 'color-functions', 'if-function', 'legacy-js-api'],
   },
 };
 

--- a/pages/wrap.tsx
+++ b/pages/wrap.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { Alert, Button, ButtonGroup, Card, Form, Modal, Spinner, ToggleButton } from 'react-bootstrap';
+import { Alert, Button, Card, Form, Modal, Spinner } from 'react-bootstrap';
+import SegmentedControl from '../components/SegmentedControl';
 import { JsonRpcProvider } from 'ethers';
 import { ai3ToShannons, shannonsToAi3 } from '@autonomys/auto-utils';
 import NetworkSelector from '../components/NetworkSelector';
@@ -379,23 +380,17 @@ export default function WrapPage() {
 
       <div className="mb-3">
         <label className="form-label fw-bold">Step 3 - Choose direction</label>
-        <ButtonGroup className="w-100">
-          {DIRECTIONS.map((d) => (
-            <ToggleButton
-              key={d}
-              id={`wrap-dir-${d}`}
-              type="radio"
-              variant={direction === d ? 'primary' : 'outline-primary'}
-              name="wrapDirToggle"
-              value={d}
-              checked={direction === d}
-              disabled={isSubmitting}
-              onChange={() => setDirection(d)}
-            >
-              {directionLabel(d, nativeSymbol, wrappedSymbol)}
-            </ToggleButton>
-          ))}
-        </ButtonGroup>
+        <SegmentedControl
+          name="wrapDirToggle"
+          ariaLabel="Wrap direction"
+          value={direction}
+          disabled={isSubmitting}
+          options={DIRECTIONS.map((d) => ({
+            value: d,
+            label: directionLabel(d, nativeSymbol, wrappedSymbol),
+          }))}
+          onChange={setDirection}
+        />
         <div className="small text-muted mt-2">
           {isWrap ? (
             <>

--- a/pages/xdm/channels.tsx
+++ b/pages/xdm/channels.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { ButtonGroup, ToggleButton } from 'react-bootstrap';
+import SegmentedControl from '../../components/SegmentedControl';
 import { fetchChannels } from '../../utils/fetchChannels';
 import ChannelList from '../../components/ChannelList';
 import ChainSummaryCard from '../../components/ChainSummaryCard';
@@ -100,30 +100,16 @@ export default function ChannelsPage() {
           </div>
           <div className="col-md-6 mb-3">
             <label className="form-label fw-bold">Select Chain:</label>
-            <ButtonGroup className="w-100">
-              <ToggleButton
-                id="toggle-consensus"
-                type="radio"
-                variant={selectedChain === 'consensus' ? 'primary' : 'outline-primary'}
-                name="chainToggle"
-                value="consensus"
-                checked={selectedChain === 'consensus'}
-                onChange={() => setSelectedChain('consensus')}
-              >
-                Consensus Chain
-              </ToggleButton>
-              <ToggleButton
-                id="toggle-autoevm"
-                type="radio"
-                variant={selectedChain === 'autoEvm' ? 'primary' : 'outline-primary'}
-                name="chainToggle"
-                value="autoEvm"
-                checked={selectedChain === 'autoEvm'}
-                onChange={() => setSelectedChain('autoEvm')}
-              >
-                Auto EVM
-              </ToggleButton>
-            </ButtonGroup>
+            <SegmentedControl
+              name="chainToggle"
+              ariaLabel="Select chain"
+              value={selectedChain}
+              onChange={setSelectedChain}
+              options={[
+                { value: 'consensus', label: 'Consensus Chain' },
+                { value: 'autoEvm', label: 'Auto EVM' },
+              ]}
+            />
           </div>
         </div>
       </div>

--- a/pages/xdm/send.tsx
+++ b/pages/xdm/send.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useRouter } from 'next/router';
-import { ButtonGroup, ToggleButton } from 'react-bootstrap';
+import SegmentedControl from '../../components/SegmentedControl';
 import NetworkSelector from '../../components/NetworkSelector';
 import SubstrateWalletConnect from '../../components/wallet/SubstrateWalletConnect';
 import EvmWalletConnect from '../../components/wallet/EvmWalletConnect';
@@ -100,25 +100,16 @@ export default function SendPage() {
 
       <div className="mb-4">
         <label className="form-label fw-bold">Transfer Direction:</label>
-        <ButtonGroup className="w-100">
-          {DIRECTIONS.map((d) => (
-            <ToggleButton
-              key={d.value}
-              id={`dir-${d.value}`}
-              type="radio"
-              variant={direction === d.value ? 'primary' : 'outline-primary'}
-              name="directionToggle"
-              value={d.value}
-              checked={direction === d.value}
-              onChange={() => {
-                setDirection(d.value);
-                setSubmitError(null);
-              }}
-            >
-              {d.label}
-            </ToggleButton>
-          ))}
-        </ButtonGroup>
+        <SegmentedControl
+          name="directionToggle"
+          ariaLabel="Transfer direction"
+          value={direction}
+          options={DIRECTIONS}
+          onChange={(value) => {
+            setDirection(value);
+            setSubmitError(null);
+          }}
+        />
       </div>
 
       <div className="mb-4">

--- a/styles/theme.scss
+++ b/styles/theme.scss
@@ -109,3 +109,48 @@ body {
 .site-footer a:hover {
   color: $primary;
 }
+
+// Segmented control — modern replacement for joined toggle button groups
+.segmented {
+  display: flex;
+  width: 100%;
+  gap: 2px;
+  padding: 3px;
+  background: #eceef1;
+  border-radius: 0.6rem;
+}
+
+.segmented__option {
+  flex: 1 1 0;
+  margin: 0;
+  text-align: center;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.75rem;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  color: var(--bs-secondary-color);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.segmented__option:not(.segmented__option--active):hover {
+  color: var(--bs-body-color);
+}
+
+.segmented__option--active {
+  background: #fff;
+  color: $primary;
+  box-shadow: inset 0 0 0 1.5px $primary, var(--st-shadow-sm);
+}
+
+.segmented__option:has(input:focus-visible) {
+  outline: 2px solid $primary;
+  outline-offset: 1px;
+}
+
+.segmented__option:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.55;
+}


### PR DESCRIPTION
Replaces the dated joined-button toggles (`ButtonGroup` + `ToggleButton`) with a modern segmented control.

### What changed
- New reusable `SegmentedControl` component — a pill track where the active option is a white thumb with an indigo ring. Backed by real radio inputs, so keyboard and screen-reader behaviour matches a native radio group.
- Rolled out to every toggle in the app:
  - **Select Network** (all tool pages, via `NetworkSelector`)
  - **Transfer Direction** (`xdm/send`)
  - **Choose direction** / Wrap–Unwrap (`wrap`)
  - **Select Chain** (`xdm/channels`)
- `react-bootstrap`'s `ButtonGroup`/`ToggleButton` imports removed from those pages.
- Silenced two more Dart Sass deprecation warnings (`if-function`, `legacy-js-api`) coming from Bootstrap's own stylesheets.

Behaviour is unchanged — same values and handlers (send still clears the submit error on change; wrap still disables while submitting).

### Note
No overlap with the still-open #24 (footer/header tweaks) — disjoint files, no conflict in either merge order.

`tsc` passes and the static export builds clean. Reviewed in-browser across all four pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and component refactor only; selection state and callbacks are preserved with no wallet or transfer logic changes.
> 
> **Overview**
> Introduces a reusable **SegmentedControl** (pill track + hidden radio inputs, `radiogroup` / `aria-label`) and uses it everywhere the app previously used **react-bootstrap** `ButtonGroup` + `ToggleButton`.
> 
> **NetworkSelector** and the direction/chain toggles on **wrap**, **xdm/send**, and **xdm/channels** now map options into `SegmentedControl` with the same `name`, values, handlers, and existing UX hooks (e.g. send still clears submit error on direction change; wrap still disables while submitting). Bootstrap toggle imports are removed from those pages.
> 
> **theme.scss** adds `.segmented` styling (active thumb, hover, focus-visible, disabled). **next.config.ts** extends Sass `silenceDeprecations` for `if-function` and `legacy-js-api` from Bootstrap’s stylesheets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58227f7f701969ce7a5ef064b3ba600f1c717973. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->