### PR TITLE
ci: harden deploy workflow (npm ci, SHA-pinned actions, least-privilege token)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,16 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    # Least privilege: gh-pages deploy only needs to push the built site to
+    # the gh-pages branch, which is a repo-contents write. Declaring the block
+    # drops every other GITHUB_TOKEN scope to none for this job.
+    permissions:
+      contents: write
 
     steps:
       - name: 🛎 Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get npm cache path
         id: npm-cache-dir-path
@@ -21,7 +26,7 @@ jobs:
         shell: bash
 
       - name: ⚡ NPM Cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -29,7 +34,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: 🔧 Install dependencies
-        run: npm install
+        run: npm ci
         shell: bash
 
       - name: 🚀 Deploy


### PR DESCRIPTION
## What

Hardens the GitHub Pages deploy workflow (`.github/workflows/deploy.yml`) — the deploy-integrity items (§1) from #30.

- **`npm install` → `npm ci`** — strictly enforces the committed `package-lock.json`, so a malicious or semver-drifted transitive dependency can't slip in at build time.
- **SHA-pin actions** — `actions/checkout` → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) and `actions/cache` → `6f8efc29b200d32929f49075959781ed54ec270c` (v3.5.0), instead of mutable `@v4`/`@v3` tags.
- **Least-privilege token** — explicit job-level `permissions: contents: write`, which drops every other `GITHUB_TOKEN` scope for the deploy job (the gh-pages push only needs contents write).

## Why

A compromised deploy serves a malicious frontend straight to users' wallet-connected browsers — the highest-impact compromise for this app. There is no known active exploit (the workflow runs only on push-to-`main` / `workflow_dispatch`, never on untrusted PRs), but these are standard supply-chain blast-radius reductions.

## Validation

- `npm ci --dry-run` passes locally — `package.json` and `package-lock.json` are in sync (557 packages resolved), so `npm ci` will succeed.
- ⚠️ **This PR does not exercise the deploy workflow in CI** — it triggers on push to `main`, not on PRs, so the first live run is on merge. The `npm ci` change is validated by the dry-run above; the SHA pins and permissions block are static YAML.

## Scope

Addresses §1 of #30. The remaining items in that issue (release-time on-chain verification, optional CSP) are out of scope here and stay open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only deploy hardening with no application or runtime logic changes; first full workflow run happens on merge to main.
> 
> **Overview**
> Hardens the GitHub Pages **deploy** workflow to shrink supply-chain and token blast radius on **main** deploys.
> 
> The install step switches from **`npm install`** to **`npm ci`**, so CI installs exactly what **`package-lock.json`** pins instead of allowing semver drift at build time. **`actions/checkout`** and **`actions/cache`** move from mutable version tags to **commit SHA pins** (with version comments), reducing risk from retagged third-party action releases.
> 
> The deploy job adds explicit **`permissions: contents: write`**, limiting **`GITHUB_TOKEN`** to what gh-pages needs to push the built site rather than inheriting broader default scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8a4ebb7f435a1f9d43e1abea78692e0bcd33d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->