### PR TITLE
feat: add baseline meta-tag Content-Security-Policy (defense-in-depth)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,19 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <div className={`${inter.className} d-flex flex-column min-vh-100`}>
       <Head>
+        {/*
+          Baseline defense-in-depth CSP. Only the directives that are safe to
+          enforce from a static-export <meta> tag (no server, so no nonces):
+          none of these govern script/style/connect, so hydration, Bootstrap,
+          RPC/indexer calls, and wallet connect are unaffected.
+          The high-value pieces — a connect-src allowlist and frame-ancestors
+          (anti-clickjacking) — are deferred until Pages sits behind a CDN that
+          can set real headers and a Report-Only rollout. See issue #30.
+        */}
+        <meta
+          httpEquiv="Content-Security-Policy"
+          content="object-src 'none'; base-uri 'self'; form-action 'self'"
+        />
         <title>Subspace Tools</title>
         <meta name="description" content="A collection of tools for working with the Autonomys Network and ecosystem." />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />


### PR DESCRIPTION
## What

Adds a baseline Content-Security-Policy via a `<meta http-equiv>` in `pages/_app.tsx`:

```
object-src 'none'; base-uri 'self'; form-action 'self'
```

## Why only these three

This is the subset of CSP that is **safe to enforce from a static-export meta tag** — it needs no nonces and governs nothing the app actually loads:

- **`base-uri 'self'`** — the real lever: blocks an injected `<base>` tag from rewriting where relative `/_next/...` scripts resolve from (an XSS amplifier). The app sets no `<base>`.
- **`object-src 'none'`** — removes legacy `<object>`/`<embed>` plugin vectors; the app uses none.
- **`form-action 'self'`** — every form here `preventDefault()`s and is handled in JS, so this is never exercised (and `'self'` would allow same-origin anyway).

Because none of these touch `script-src` / `style-src` / `connect-src`, **hydration, Bootstrap styling, RPC/indexer requests, and wallet connect are unaffected** — safe by construction, which is why they don't need the runtime test pass a `connect-src` policy would.

## Why not connect-src / frame-ancestors here

Deferred to **"when we put a CDN in front of Pages"** (tracked in #30):

- **`connect-src` allowlist** — meta CSP is **enforce-only** (no `Report-Only` via meta), and the Autonomys SDKs open their own RPC sockets not listed in `config/networks.ts`, so a missed origin would silently break balance/transfer reads in production. Needs a CDN/header + a `Content-Security-Policy-Report-Only` rollout to do safely.
- **`frame-ancestors 'none'`** (anti-clickjacking for the signing UI) and `X-Frame-Options` are **header-only** — unsettable from a Pages meta tag.

## Risk

Zero runtime risk by construction (see above). As with the deploy workflow, the live site only rebuilds on merge to `main`; this is static markup and doesn't alter the build.

## Scope

Part of §3 of #30; the deferred, CDN-dependent CSP work stays open there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static markup-only change with CSP directives that do not govern scripts, styles, or fetch targets; no auth or data-path changes.
> 
> **Overview**
> Adds a **defense-in-depth CSP** via `<meta httpEquiv="Content-Security-Policy">` in `pages/_app.tsx`, enforcing `object-src 'none'`, `base-uri 'self'`, and `form-action 'self'`.
> 
> These directives are chosen because they are safe on a **static-export** site without nonces and do **not** touch `script-src`, `style-src`, or `connect-src`, so Next hydration, Bootstrap, RPC options RPC/indexer traffic, and wallet connect should behave as before. Inline comments document that **`connect-src`** and **`frame-ancestors`** stay deferred until Pages is behind a CDN (issue #30).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4622a2aba54b599def5b0bbcdbe97d1fcd99f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->