### PR TITLE
docs+test: release-verification runbook + tx-input invariant tripwire (#30 §2.2/§2.3)

### DIFF
--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,71 @@
+# Release verification
+
+Checks to run before a release. The automated parts gate CI; the manual
+round-trip is the one thing only a human with a wallet can do — and it's the
+highest-assurance check we have that funds actually move correctly end to end.
+
+**Why this exists.** A security audit found no fund-safety bug in the app code,
+but the Autonomys SDKs (`@autonomys/auto-xdm`, `auto-wallet`, `auto-utils`) and
+the live contracts are trusted black boxes: the code is verified to pass them
+correct, exact-precision arguments, but their internal behaviour is not. The
+round-trip below is how we confirm that reality. See issue #30 §2.
+
+## Automated (already gating CI)
+
+- **Config integrity** — `npm test` (hermetic) on every PR, plus the live
+  on-chain check (`npm run test:onchain`) on any PR that edits
+  `config/networks.ts`, confirming each `wai3Address` is a real WAI3 contract on
+  its configured chain. (#30 §2.1)
+- **Tx-input invariant** — `test/tx-input-invariant.test.ts` fails if a
+  transaction-submission page starts reading URL query params (see *Standing
+  invariants* below). (#30 §2.3)
+
+## Manual: testnet round-trip (#30 §2.2)
+
+Do this on **Chronos testnet** (native `tAI3`) so no real funds are at risk.
+Obtain test `tAI3` from the Autonomys Chronos faucet (see the Autonomys docs).
+You need a Substrate wallet (e.g. SubWallet/Talisman) and an EVM wallet (e.g.
+MetaMask/Rabby), both holding a little `tAI3`.
+
+For **every** flow, confirm the **exact amount** and the **exact destination**
+on the block explorer — do not trust the app's success message alone. Chronos
+explorers: consensus → <https://autonomys-chronos.subscan.io>, Auto EVM →
+<https://explorer.auto-evm.chronos.autonomys.xyz>. Use a round amount `N` ≥ 1
+`tAI3` (the send form enforces a 1 AI3 minimum for XDM transfers).
+
+### 1. Wrap — instant
+- [ ] On `/wrap` with Chronos selected and the wallet on Auto EVM (chain 8700), wrap `N` `tAI3`.
+- [ ] Native balance dropped by `N` + gas; WAI3 balance rose by **exactly** `N`.
+- [ ] The `deposit()` tx on the Auto EVM explorer shows value = `N`.
+
+### 2. Unwrap — instant
+- [ ] On `/wrap`, unwrap `N` WAI3.
+- [ ] WAI3 balance dropped by **exactly** `N`; native balance rose by `N` − gas.
+- [ ] The `withdraw(N)` tx on the Auto EVM explorer shows the right amount.
+
+### 3. Consensus → Auto EVM (XDM) — ~10 min
+- [ ] On `/xdm/send`, direction **Consensus → Auto EVM**, recipient = your EVM address, amount `N`.
+- [ ] Track on `/xdm/transfers`; wait for execution (~10 min / 100 domain blocks).
+- [ ] On the Auto EVM explorer, **your EVM address** received the expected amount, and it matches the address you entered (not truncated or altered).
+
+### 4. Auto EVM → Consensus (XDM) — ~1 day
+- [ ] On `/xdm/send`, direction **Auto EVM → Consensus**, recipient = your Substrate (SS58) address, amount `N`.
+- [ ] Track on `/xdm/transfers`; this direction finalises in ~1 day (14,400 domain blocks).
+- [ ] On Subscan, **your Substrate address** received the expected amount.
+
+> Asymmetry to plan around: wrap/unwrap and Consensus→EVM are quick; EVM→Consensus
+> takes ~1 day, so kick it off early or verify it out-of-band of the release cut.
+
+## Standing invariants
+
+These must hold in any change. Breaking one means re-auditing the fund-safety
+argument — not just updating the check.
+
+- **No transaction input from external data.** Recipient, amount, and chain for
+  any transaction come *only* from user-entered form state — never from URL
+  query params, the indexer, or RPC responses. The URL-param vector is enforced
+  by `test/tx-input-invariant.test.ts`; indexer/RPC-sourced inputs must be
+  caught in review. (#30 §2.3)
+- **Send the exact confirmed string.** Every flow passes the exact amount string
+  the user confirmed to `ai3ToShannons` — no float ever touches the sent value,
+  and the precision library throws (never silently rounds) on bad input. (#30 §2)

--- a/test/tx-input-invariant.test.ts
+++ b/test/tx-input-invariant.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+// Invariant (issue #30 §2.3): the transaction-submission paths take
+// recipient / amount / chain ONLY from user-entered form state — never from URL
+// query params or indexer/RPC responses. This is a tripwire for the most likely
+// regression: wiring a query param (e.g. a "prefill recipient from a shared
+// link" feature) into the send/wrap forms.
+//
+// If this fails because you intentionally introduced such a flow, do NOT just
+// delete the check — re-audit the fund-safety argument first (see
+// docs/release-verification.md), then update the invariant.
+//
+// Scope/limit: this targets the URL-query-param vector via the common idioms
+// below. It is a smell test, not a proof; indexer/RPC-sourced inputs must still
+// be caught in review.
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const SUBMIT_PATH_FILES = [
+  'pages/xdm/send.tsx',
+  'pages/wrap.tsx',
+  'components/SendForm.tsx',
+];
+
+const FORBIDDEN_URL_PARAM_READS = [
+  /\brouter\.query\b/, // next/router (pages router) query bag
+  /\buseSearchParams\b/, // next/navigation hook
+  /\bwindow\.location\.search\b/, // raw query string
+];
+
+describe('tx-input invariant: submit paths read no URL query params (#30 §2.3)', () => {
+  it.each(SUBMIT_PATH_FILES)('%s does not read URL query params', (rel) => {
+    const src = readFileSync(join(ROOT, rel), 'utf8');
+    for (const pattern of FORBIDDEN_URL_PARAM_READS) {
+      expect(
+        src,
+        `${rel} matches ${pattern} — see #30 §2.3 / docs/release-verification.md before wiring URL or external data into a transaction input`,
+      ).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
Closes out the two remaining §2 items from #30.

## §2.2 — release-verification runbook (`docs/release-verification.md`)

The manual testnet round-trip is the only way to validate the Autonomys SDKs and contracts *by value* — they're trusted black boxes, so the audit confirmed the app passes them correct, exact-precision arguments but not what they do internally. The doc is a copy-pasteable checklist covering **wrap, unwrap, and both XDM directions** on **Chronos testnet** (no real funds), each with "confirm the exact amount and destination on the explorer" steps. It also records the automated checks and the standing fund-safety invariants in one place.

## §2.3 — tx-input invariant tripwire (`test/tx-input-invariant.test.ts`)

Fails if any transaction-submission file — `pages/xdm/send.tsx`, `pages/wrap.tsx`, `components/SendForm.tsx` — starts reading URL query params (`router.query` / `useSearchParams` / `window.location.search`). That's the most likely way the *"no transaction input from external data"* invariant would regress (e.g. a "prefill recipient from a shared link" feature wiring a param into the form).

**Honest scope:** it targets the URL-param vector — a smell test, not a proof. Indexer/RPC-sourced inputs still need to be caught in review. The test comment and the doc both say so, and both say *re-audit, don't just delete the check* if it fires on an intentional change.

## Validation

- `npm test` → 7 passed / 6 skipped (the 3 new tripwire cases pass against current code).
- Tripwire regex sanity-checked both ways: matches `router.query` / `useSearchParams` / `window.location.search`; ignores the `router.push` and `new URLSearchParams(...)` idioms the app already uses.
- `npm run lint` clean; `npm run build` exports cleanly.

## Issue status (#30 §2)

- **§2.3** is now enforced + documented → tickable on merge.
- **§2.2**'s runbook is delivered, but the box stays open until someone actually runs the testnet round-trip — the SDK validation is the human step; this PR just enables it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static source-pattern tests only; no runtime, auth, or transaction logic changes.
> 
> **Overview**
> Adds **`docs/release-verification.md`**, a pre-release checklist that ties together existing CI checks (config/on-chain tests) with a **manual Chronos testnet round-trip** (wrap, unwrap, both XDM directions) and documents **standing fund-safety invariants** (no external tx inputs; exact confirmed amount strings).
> 
> Adds **`test/tx-input-invariant.test.ts`**, a Vitest tripwire that fails if `pages/xdm/send.tsx`, `pages/wrap.tsx`, or `components/SendForm.tsx` start reading URL query params via `router.query`, `useSearchParams`, or `window.location.search`. The doc and test comments state this is a smell test for the URL-param regression vector—not proof against indexer/RPC-sourced inputs—and that intentional changes require re-audit before relaxing the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69be3c3b4ee30483c511b25e39df5d8822480f42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->