### PR TITLE
fix(deps): upgrade ethers 6.17.0 & js-yaml 4.2.0 to clear Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@autonomys/auto-xdm": "^1.6.14",
         "@polkadot/api": "^15.8.1",
         "bootstrap": "^5.3.3",
-        "ethers": "^6.16.0",
+        "ethers": "^6.17.0",
         "next": "15.5.18",
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/@autonomys/auto-consensus": {
@@ -5645,9 +5645,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
       "funding": [
         {
           "type": "individual",
@@ -5660,13 +5660,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
+        "@adraffy/ens-normalize": "1.11.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
         "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.7.0",
-        "ws": "8.17.1"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5710,27 +5710,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
-    },
-    "node_modules/ethers/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -6814,10 +6793,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@autonomys/auto-xdm": "^1.6.14",
     "@polkadot/api": "^15.8.1",
     "bootstrap": "^5.3.3",
-    "ethers": "^6.16.0",
+    "ethers": "^6.17.0",
     "next": "15.5.18",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",


### PR DESCRIPTION
Clears the three open Dependabot alerts by upgrading to patched versions the manifests already permit — no `overrides` / forced pins.

## Changes

- **`ethers` `^6.16.0` → `^6.17.0`.** `ethers@6.16.0` pinned `ws: 8.17.1` (exact), which is the vulnerable version; `ethers@6.17.0` pins `ws: 8.21.0` (patched). The bump pulls the fixed `ws` naturally and the vulnerable nested `ethers/node_modules/ws@8.17.1` is removed (ethers dedupes onto the hoisted `ws@8.21.0`).
  - Clears **#62** (high — [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p)) and **#61** (med — [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx)).
- **`js-yaml` `4.1.1` → `4.2.0`** (lockfile only). `@eslint/eslintrc` already declares `js-yaml: ^4.1.1`, which permits 4.2.0 — the lockfile was just pinned to the older patch. No manifest change, no override.
  - Clears **#63** (med — [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).

## Why upgrade rather than `overrides`

Both fixes are versions the existing dependency ranges already allow, so this is a normal upgrade rather than forcing a version a parent never declared support for. Only `ethers` needed an explicit manifest floor (so a fresh resolve can't regress below the patched `ws`); `js-yaml` is purely transitive and needed no manifest edit.

## Validation

- `npm audit` → **0 vulnerabilities**.
- `npm test` and `npm run test:onchain` pass — the latter exercises the actual ethers `JsonRpcProvider` + `Contract` path against both live chains, confirming the minor bump is behaviourally clean for how the app uses ethers.
- `npm run lint` clean; `npm run build` exports cleanly.
- Net lockfile change is −11 lines (the duplicate `ws` subtree is removed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch/minor bumps within existing semver ranges; no application code changes, with on-chain tests noted as validation for the ethers bump.
> 
> **Overview**
> Bumps the direct **`ethers`** dependency from **`^6.16.0`** to **`^6.17.0`** in `package.json`, with matching lockfile updates. That release moves its pinned **`ws`** from **8.17.1** to **8.21.0** and drops the nested vulnerable **`ethers/node_modules/ws`** copy in favor of the hoisted patched version, addressing the open **`plan alerts tied to **`ws`**.
> 
> The lockfile also refreshes transitive patches without manifest edits: **`@adraffy/ens-normalize`** (via **`ethers`**) to **1.11.1**, and **`js-yaml`** from **4.1.1** to **4.2.0** (still allowed by **`@eslint/eslintrc`**’s **`^4.1.1`** range) for the remaining advisory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c18aa8cccfc13c784691613ae2fe997862fbe8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->